### PR TITLE
Use header field for authorization with access token from Keycloak

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,35 @@
+# share-square-hub
+
+### Deployment
+
+Define authorization properties in the **application.properties** file:
+
+* auth.server.domain
+* auth.server.realm
+* auth.server.scope
+
+or use environment variables:
+
+* SHARE2_AUTH_SERVER_DOMAIN
+* SHARE2_AUTH_SERVER_REALM
+* SHARE2_AUTH_SERVER_SCOPE
+
+Run **HubMain.java** or
+
+```
+$ ./gradlew bootRun
+```
+
+### Authorization
+
+Get access token from Keycloak:
+
+```
+curl -H "Content-Type: application/x-www-form-urlencoded" \
+  -d "client_id=xxx" \
+  -d "client_secret=xxx" \
+  -d "grant_type=client_credentials" \
+  -X POST http://localhost:9080/auth/realms/heroes/protocol/openid-connect/token
+```
+
+Authorize request with header `"Authorization: Bearer {access_token}"`

--- a/build.gradle
+++ b/build.gradle
@@ -66,7 +66,7 @@ dependencies {
     implementation group: 'javax.annotation', name: 'javax.annotation-api', version: '1.3.2'
 
     implementation 'org.springframework.boot:spring-boot-starter-web'
-    implementation group: 'org.springdoc', name: 'springdoc-openapi-ui', version: '1.1.45'
+    implementation 'org.springdoc:springdoc-openapi-ui:1.4.0'
     implementation 'org.springframework.data:spring-data-commons:2.3.0.RELEASE'
     implementation 'org.springframework.boot:spring-boot-starter-webflux:2.3.0.RELEASE'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'

--- a/build.gradle
+++ b/build.gradle
@@ -63,12 +63,10 @@ dependencies {
     implementation group: 'org.springdoc', name: 'springdoc-openapi-ui', version: '1.1.45'
     implementation group: 'org.springframework.data', name: 'spring-data-commons', version: '2.2.5.RELEASE'
     implementation group: 'org.springframework.boot', name: 'spring-boot-starter-webflux', version: '2.2.5.RELEASE'
-    implementation group: 'org.springframework.security', name: 'spring-security-oauth2-jose', version: '5.3.0.RELEASE'
-    implementation group: 'org.springframework.security', name: 'spring-security-core', version: '5.3.0.RELEASE'
-    implementation group: 'org.springframework.security', name: 'spring-security-oauth2-resource-server', version:'5.3.0.RELEASE'
-    implementation group: 'org.springframework.security', name: 'spring-security-oauth2-client', version:'5.3.0.RELEASE'
-
-    implementation group: 'org.springframework.boot', name: 'spring-boot-starter-security', version: '2.2.5.RELEASE'
+	implementation 'org.springframework.boot:spring-boot-starter-security'
+	implementation 'org.springframework.boot:spring-boot-starter-oauth2-resource-server'
+	implementation 'org.springframework.security:spring-security-oauth2-jose:5.2.4.RELEASE'
+	//implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
 
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
@@ -80,10 +78,11 @@ dependencies {
 		exclude group: 'org.junit.vintage', module: 'junit-vintage-engine'
 	}
     //testCompile group: 'com.squareup.okhttp3', name: 'mockwebserver', version: '4.4.1'
-    //testImplementation "org.springframework.security:spring-security-test"
+	testImplementation 'org.springframework.security:spring-security-test'
 	testImplementation 'org.spockframework:spock-core:1.3-groovy-2.5'
 	testImplementation 'org.spockframework:spock-spring:1.3-groovy-2.5'
-	testCompile 'com.athaydes:spock-reports:1.3.2', { transitive = false }
+	testImplementation 'org.codehaus.groovy.modules.http-builder:http-builder:0.7.1'
+	testImplementation 'com.athaydes:spock-reports:1.3.2'
 }
 
 test {

--- a/build.gradle
+++ b/build.gradle
@@ -62,7 +62,7 @@ configurations.all {
 
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
-    implementation 'io.micrometer:micrometer-registry-prometheus:1.3.6'
+    implementation 'io.micrometer:micrometer-registry-prometheus:1.5.1'
     implementation group: 'javax.annotation', name: 'javax.annotation-api', version: '1.3.2'
 
     implementation 'org.springframework.boot:spring-boot-starter-web'

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id "io.freefair.lombok" version "4.1.5"
-    id 'org.springframework.boot' version '2.2.6.RELEASE'
+    id 'org.springframework.boot' version '2.3.0.RELEASE'
     id 'io.spring.dependency-management' version '1.0.9.RELEASE'
 	id 'java'
 	id 'groovy'
@@ -8,6 +8,12 @@ plugins {
 
 sourceCompatibility = 8
 targetCompatibility = 8
+
+configurations {
+	compileOnly {
+		extendsFrom annotationProcessor
+	}
+}
 
 Properties properties = new Properties()
 def propertiesFile = project.rootProject.file('local.properties')
@@ -61,11 +67,11 @@ dependencies {
 
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation group: 'org.springdoc', name: 'springdoc-openapi-ui', version: '1.1.45'
-    implementation group: 'org.springframework.data', name: 'spring-data-commons', version: '2.2.5.RELEASE'
-    implementation group: 'org.springframework.boot', name: 'spring-boot-starter-webflux', version: '2.2.5.RELEASE'
+    implementation 'org.springframework.data:spring-data-commons:2.3.0.RELEASE'
+    implementation 'org.springframework.boot:spring-boot-starter-webflux:2.3.0.RELEASE'
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-oauth2-resource-server'
-	implementation 'org.springframework.security:spring-security-oauth2-jose:5.2.4.RELEASE'
 	//implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
 
     compileOnly 'org.projectlombok:lombok'

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.2.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.1-all.zip

--- a/src/main/java/org/sharesquare/hub/configuration/OpenApiConfiguration.java
+++ b/src/main/java/org/sharesquare/hub/configuration/OpenApiConfiguration.java
@@ -1,26 +1,43 @@
 package org.sharesquare.hub.configuration;
 
+
+import java.util.Collections;
+
+import org.apache.tomcat.websocket.Constants;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
 import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
 import io.swagger.v3.oas.models.info.License;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
 import io.swagger.v3.oas.models.security.SecurityScheme;
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
 
 @Configuration
 public class OpenApiConfiguration {
 
+	private static final String AUTH = "OAuth 2.0";
 
     @Bean
     public OpenAPI customOpenAPI() {
         return new OpenAPI()
-                .components(new Components().addSecuritySchemes("basicScheme",
-                        new SecurityScheme().type(SecurityScheme.Type.HTTP).scheme("basic")))
+                .components(new Components().addSecuritySchemes(AUTH, authorizationSecuritySchema()))
                 .info(new Info().title("ShareSquare HUB API").version("1").description(
                         "ShareSquare HUB API.  You can find out more about     Swagger at [http://swagger.io](http://swagger.io) or on [irc.freenode.net, #swagger](http://swagger.io/irc/).      For this sample, you can use the api key `special-key` to test the authorization     filters.")
                         .termsOfService("http://swagger.io/terms/")
-                        .license(new License().name("Apache 2.0").url("http://springdoc.org")));
+                        .license(new License().name("Apache 2.0").url("http://springdoc.org")))
+                .security(Collections.singletonList(new SecurityRequirement().addList(AUTH)));
     }
 
+	public SecurityScheme authorizationSecuritySchema() {
+		return new SecurityScheme()
+				.type(SecurityScheme.Type.HTTP)
+				.scheme("bearer")
+				.bearerFormat("JWT")
+				.name(Constants.AUTHORIZATION_HEADER_NAME)
+				.description(
+						"Authorization header using the Bearer scheme <b>\"Authorization: Bearer &lt;Value&gt;\"</b> where Value is the access token.")
+				.in(SecurityScheme.In.HEADER);
+	}
 }

--- a/src/main/java/org/sharesquare/hub/configuration/SecurityConfiguration.java
+++ b/src/main/java/org/sharesquare/hub/configuration/SecurityConfiguration.java
@@ -14,6 +14,7 @@ import org.springframework.http.HttpMethod;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.builders.WebSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
 import org.springframework.security.config.annotation.web.configurers.oauth2.server.resource.OAuth2ResourceServerConfigurer;
@@ -88,6 +89,14 @@ public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
 	@Override
 	protected void configure(AuthenticationManagerBuilder auth) throws Exception {
 		// do NOT call super.configure()
+	}
+
+	@Override
+	public void configure(WebSecurity web) {
+		web.ignoring().antMatchers(
+				"/v3/api-docs", 
+				"/swagger-ui.html", 
+				"/swagger-ui/**");
 	}
 
 	@Override

--- a/src/main/java/org/sharesquare/hub/configuration/SecurityConfiguration.java
+++ b/src/main/java/org/sharesquare/hub/configuration/SecurityConfiguration.java
@@ -93,8 +93,8 @@ public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
 
 	@Override
 	public void configure(WebSecurity web) {
-		web.ignoring().antMatchers(
-				"/v3/api-docs", 
+		web.ignoring().mvcMatchers(
+				"/v3/api-docs/**", 
 				"/swagger-ui.html", 
 				"/swagger-ui/**");
 	}

--- a/src/main/java/org/sharesquare/hub/endpoints/Offers.java
+++ b/src/main/java/org/sharesquare/hub/endpoints/Offers.java
@@ -63,10 +63,12 @@ public class Offers {
         return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(null);
     }
 
-    @Operation(description = "Create an Offer")
-    @ApiResponse(responseCode = "201", description = "Success")
-    @ApiResponse(responseCode = "400", description = "Wrong data input", content = @Content)
-    @ApiResponse(responseCode = "415", description = "Wrong format", content = @Content)
+    @Operation(description = "Add a new Offer")
+    @ApiResponse(responseCode = "201", description = "Success", content = @Content)
+    @ApiResponse(responseCode = "400", description = "Wrong data input")
+    @ApiResponse(responseCode = "415", description = "Wrong format")
+    @ApiResponse(responseCode = "401", description = "Wrong client authorization")
+    @ApiResponse(responseCode = "403", description = "Client not allowed")
     @PostMapping(path = "/offers", produces = MediaType.APPLICATION_JSON_VALUE, consumes = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<Offer> createOffer(@Valid @RequestBody Offer offer) {
 

--- a/src/main/java/org/sharesquare/hub/exception/ResponseError.java
+++ b/src/main/java/org/sharesquare/hub/exception/ResponseError.java
@@ -3,6 +3,8 @@ package org.sharesquare.hub.exception;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 
+import javax.servlet.http.HttpServletRequest;
+
 import org.springframework.http.HttpStatus;
 import org.springframework.web.context.request.ServletWebRequest;
 import org.springframework.web.context.request.WebRequest;
@@ -26,9 +28,18 @@ public class ResponseError {
 	private String path;
 
 	public ResponseError(HttpStatus status, String message, WebRequest request) {
+		setValues(status, message);
+		this.path = ((ServletWebRequest) request).getRequest().getRequestURI();
+	}
+
+	public ResponseError(HttpStatus status, String message, HttpServletRequest request) {
+		setValues(status, message);
+		this.path = request.getRequestURI();
+	}
+
+	private void setValues(HttpStatus status, String message) {
 		this.status = status.value();
 		this.error = status.getReasonPhrase();
 		this.message = message;
-		this.path = ((ServletWebRequest) request).getRequest().getRequestURI();
 	}
 }

--- a/src/main/java/org/sharesquare/hub/exception/RestAccessDeniedHandler.java
+++ b/src/main/java/org/sharesquare/hub/exception/RestAccessDeniedHandler.java
@@ -1,0 +1,38 @@
+package org.sharesquare.hub.exception;
+
+import static org.springframework.http.HttpStatus.FORBIDDEN;
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+
+import java.io.IOException;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+@Component
+public class RestAccessDeniedHandler implements AccessDeniedHandler {
+
+	private static final Logger log = LoggerFactory.getLogger(RestAccessDeniedHandler.class);
+
+	@Autowired
+	ObjectMapper objectMapper;
+
+	@Override
+	public void handle(HttpServletRequest request, HttpServletResponse response, AccessDeniedException e)
+			throws IOException, ServletException {
+		response.setContentType(APPLICATION_JSON_VALUE);
+		response.setStatus(FORBIDDEN.value());
+		ResponseError error = new ResponseError(FORBIDDEN, e.getMessage(), request);
+		objectMapper.writeValue(response.getOutputStream(), error);
+		log.info("No Access: {}: {}", e.getClass().getName(), e.getMessage());
+	}
+}

--- a/src/main/java/org/sharesquare/hub/exception/RestAuthenticationEntryPoint.java
+++ b/src/main/java/org/sharesquare/hub/exception/RestAuthenticationEntryPoint.java
@@ -1,0 +1,42 @@
+package org.sharesquare.hub.exception;
+
+import static org.springframework.http.HttpStatus.UNAUTHORIZED;
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+
+import java.io.IOException;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.authentication.InsufficientAuthenticationException;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+@Component
+public class RestAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+	private static final Logger log = LoggerFactory.getLogger(RestAuthenticationEntryPoint.class);
+
+	@Autowired
+	ObjectMapper objectMapper;
+
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException e) throws IOException, ServletException {
+    	response.setContentType(APPLICATION_JSON_VALUE);
+    	response.setStatus(UNAUTHORIZED.value());
+    	String message = e.getMessage();
+    	if (e instanceof InsufficientAuthenticationException) {
+    		message = String.format("Insufficient authentication: %s", message);
+    	}
+    	ResponseError error = new ResponseError(UNAUTHORIZED, message, request);
+    	objectMapper.writeValue(response.getOutputStream(), error);
+        log.info("Authentication problem: {}: {}", e.getClass().getName(), e.getMessage());
+    }
+}

--- a/src/main/java/org/sharesquare/hub/exception/RestAuthenticationFailureHandler.java
+++ b/src/main/java/org/sharesquare/hub/exception/RestAuthenticationFailureHandler.java
@@ -1,0 +1,38 @@
+package org.sharesquare.hub.exception;
+
+import static org.springframework.http.HttpStatus.UNAUTHORIZED;
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+
+import java.io.IOException;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.authentication.AuthenticationFailureHandler;
+import org.springframework.stereotype.Component;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+@Component
+public class RestAuthenticationFailureHandler implements AuthenticationFailureHandler {
+
+	private static final Logger log = LoggerFactory.getLogger(RestAuthenticationFailureHandler.class);
+
+	@Autowired
+	ObjectMapper objectMapper;
+
+	@Override
+	public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response,
+			AuthenticationException e) throws IOException, ServletException {
+		response.setContentType(APPLICATION_JSON_VALUE);
+		response.setStatus(UNAUTHORIZED.value());
+		ResponseError error = new ResponseError(UNAUTHORIZED, e.getMessage(), request);
+		objectMapper.writeValue(response.getOutputStream(), error);
+		log.info("Authentication failure: {}: {}", e.getClass().getName(), e.getMessage());
+	}
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,3 +1,13 @@
 system.appName=Share2Hub
-server.port=8080
+server.port=${SERVER_PORT:8081}
 server.contextPath=/
+
+#keycloak
+auth.server.domain=${SHARE2_AUTH_SERVER_DOMAIN:http://localhost:9080}
+auth.server.realm=${SHARE2_AUTH_SERVER_REALM:xxx}
+auth.server.scope=${SHARE2_AUTH_SERVER_SCOPE:xxx}
+
+spring.security.oauth2.resourceserver.jwt.jwk-set-uri=${auth.server.domain}/auth/realms/${auth.server.realm}/protocol/openid-connect/certs
+auth.server.issuer.uri=${auth.server.domain}/auth/realms/${auth.server.realm}
+
+logging.level.org.springframework.security=DEBUG

--- a/src/test/groovy/org/sharesquare/hub/endpoints/AuthTest.groovy
+++ b/src/test/groovy/org/sharesquare/hub/endpoints/AuthTest.groovy
@@ -1,0 +1,218 @@
+package org.sharesquare.hub.endpoints
+
+import static org.springframework.http.HttpHeaders.CONTENT_TYPE
+import static org.springframework.http.HttpHeaders.WWW_AUTHENTICATE
+import static org.springframework.http.HttpStatus.FORBIDDEN
+import static org.springframework.http.HttpStatus.OK
+import static org.springframework.http.HttpStatus.UNAUTHORIZED
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE
+
+import org.springframework.beans.factory.annotation.Value
+
+import spock.lang.Issue
+import spock.lang.Shared
+import spock.lang.Stepwise
+
+@Issue("#6")
+@Stepwise
+class AuthTest extends RequestSpecification {
+
+	@Shared token
+
+	@Value("\${token.expired}")
+	private String tokenExpired;
+
+	static final tokenPattern = /(?i)([a-z0-9]+\.){2}[a-z0-9\_\-]+/
+
+	def "The authorization server should return a access token"() {
+		when:
+			final response = authServerResponse()
+			token = response.data.access_token
+
+		then:
+			with (response) {
+				status == OK.value
+				contentType == APPLICATION_JSON_VALUE
+				data.access_token != null
+				data.access_token.matches(tokenPattern)
+			}
+	}
+
+	def "A request without authorization header should respond with status code 401 and a meaningful error message"() {
+		when:
+			final response = doPostWithoutAuthHeader()
+
+		then:
+			resultIs(response, UNAUTHORIZED)
+
+		when:
+			final responseError = fromJson(response.contentAsString, Map)
+			final expectedMessage = 'Insufficient authentication: Full authentication is required to access this resource'
+
+		then:
+			resultContentIs(responseError, UNAUTHORIZED, expectedMessage)
+	}
+
+	static final jwtError = 'An error occurred while attempting to decode the Jwt: '
+
+	def "A request with an invalid access token should respond with status code 401 and a meaningful error message"() {
+		when:
+			final response = doPostWithAuthHeaderValue("Bearer $invalid")
+
+		then:
+			resultIs(response, UNAUTHORIZED)
+
+		when:
+			final responseError = fromJson(response.contentAsString, Map)
+
+		then:
+			resultContentIs(responseError, UNAUTHORIZED, jwtError + errorDetail)
+
+		where:
+			invalid                                 | errorDetail
+			'a.b.c'                                 | 'Invalid unsecured/JWS/JWE header: Invalid JSON: Unexpected token  at position 0.'
+			'.'                                     | 'Invalid unsecured/JWS/JWE header: Invalid JSON: Unexpected token  at position 0.'
+			'a1.b.c.d'                              | 'Invalid unsecured/JWS/JWE header: Invalid JSON: Unexpected token k at position 1.'
+			'a2a.b'                                 | 'Invalid unsecured/JWS/JWE header: Invalid JSON: Unexpected token kf at position 2.'
+			'eyJ.eyJ.123'                           | 'Invalid unsecured/JWS/JWE header: Invalid JSON: Unexpected End Of File position 2: null'
+			'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzUxMiJ9.' | 'Invalid serialized unsecured/JWS/JWE object: Missing second delimiter'
+			'0'                                     | 'Invalid JWT serialization: Missing dot delimiter(s)'
+
+			"X$token"                               | 'Invalid unsecured/JWS/JWE header: Invalid JSON: Unexpected character (]) at position 0.'
+			"$token.$token"                         | 'Invalid serialized unsecured/JWS/JWE object: Too many part delimiters'
+			"e$token"                               | 'Invalid token'
+			"$token."                               | 'Invalid serialized JWE object: Missing fourth delimiter'
+			"${token}3"                             | 'Signed JWT rejected: Invalid signature'
+			"$token$token"                          | 'Unexpected number of Base64URL parts, must be three'
+
+			"${token.replaceFirst(/\./, '')}"       | 'Invalid token'
+			"${token.replaceFirst(/\./, '..')}"     | 'Invalid serialized JWE object: Missing fourth delimiter'
+			"${token.replaceFirst(/\./, '.X')}"     | 'Malformed payload'
+	}
+
+	static final malformedError = 'Bearer error="invalid_token", error_description="Bearer token is malformed", error_uri="https://tools.ietf.org/html/rfc6750#section-3.1"'
+
+	def "A request with a malformed or empty access token should respond with status code 401 and a meaningful error message in the response header"() {
+		when:
+			final response = doPostWithAuthHeaderValue("Bearer $malformed")
+
+		then:
+			with (response) {
+				status                          == UNAUTHORIZED.value
+				errorMessage                    == null
+				headers[CONTENT_TYPE]           == null
+				contentType                     == null
+				headers[WWW_AUTHENTICATE].value == malformedError
+				contentAsString                 == ''
+		}
+
+		where:
+			malformed       | _
+			'a.b.c*'        | _
+			'a.b.c!'        | _
+			'?.'            | _
+			'&'             | _
+			"$token "       | _
+			"$token $token" | _
+			''              | _
+	}
+
+	def "A request with a malformed authorization header value should respond with status code 401 and a meaningful error message in the response header"() {
+		when:
+			final response = doPostWithAuthHeaderValue(value)
+
+		then:
+			with (response) {
+				status                          == UNAUTHORIZED.value
+				errorMessage                    == null
+				headers[CONTENT_TYPE]           == null
+				contentType                     == null
+				headers[WWW_AUTHENTICATE].value == malformedError
+				contentAsString                 == ''
+		}
+
+		where:
+			value                  | _
+			"Bearer  $token"       | _
+			"Bearer$token"         | _
+			"Bearerr $token"       | _
+			"Bearer Bearer $token" | _
+	}
+
+	def "A request with an invalid or empty authorization header value should respond with status code 401 and a meaningful error message"() {
+		when:
+			final response = doPostWithAuthHeaderValue(value)
+
+		then:
+			resultIs(response, UNAUTHORIZED)
+
+		when:
+			final responseError = fromJson(response.contentAsString, Map)
+			final expectedMessage = 'Insufficient authentication: Full authentication is required to access this resource'
+
+		then:
+			resultContentIs(responseError, UNAUTHORIZED, expectedMessage)
+
+		where:
+			value            | _
+			token            | _
+			" Bearer $token" | _
+			" $token"        | _
+			"$token "        | _
+			''               | _
+			' '              | _
+	}
+
+	def "A request with an invalid or empty authorization header key should respond with status code 401 and a meaningful error message"() {
+		when:
+			final response = doPostWithAuthHeaderKey(key)
+
+		then:
+			resultIs(response, UNAUTHORIZED)
+
+		when:
+			final responseError = fromJson(response.contentAsString, Map)
+			final expectedMessage = 'Insufficient authentication: Full authentication is required to access this resource'
+
+		then:
+			resultContentIs(responseError, UNAUTHORIZED, expectedMessage)
+
+		where:
+			key              | _
+			'Authorization ' | _
+			' Authorization' | _
+			'Authorizatio'   | _
+			'&=;'            | _
+			' '              | _
+	}
+
+	def "A request with an expired access token should respond with status code 401 and a meaningful error message"() {
+		when:
+			def response = doPostWithAuthHeaderValue("Bearer $tokenExpired")
+
+		then:
+			resultIs(response, UNAUTHORIZED)
+
+		when:
+			def responseError = fromJson(response.contentAsString, Map)
+			responseError.message = responseError.message.replaceFirst(/[^ ]+$/, '')
+			final expectedMessage = 'An error occurred while attempting to decode the Jwt: Jwt expired at '
+
+		then:
+			resultContentIs(responseError, UNAUTHORIZED, expectedMessage)
+	}
+
+	def "A request with an access token not in the scope should respond with status code 403 and a meaningful error message"() {
+		when:
+			final response = doPostWithAuthHeaderValue("Bearer ${accessTokenNotInScope()}")
+
+		then:
+			resultIs(response, FORBIDDEN)
+
+		when:
+			final responseError = fromJson(response.contentAsString, Map)
+
+		then:
+			resultContentIs(responseError, FORBIDDEN, 'Access is denied')
+	}
+}

--- a/src/test/groovy/org/sharesquare/hub/endpoints/AuthTest.groovy
+++ b/src/test/groovy/org/sharesquare/hub/endpoints/AuthTest.groovy
@@ -64,6 +64,7 @@ class AuthTest extends RequestSpecification {
 
 		when:
 			final responseError = fromJson(response.contentAsString, Map)
+			responseError.message = responseError.message.replaceFirst(/ token [^ ]* at /, ' token  at ')
 
 		then:
 			resultContentIs(responseError, UNAUTHORIZED, jwtError + errorDetail)
@@ -72,20 +73,20 @@ class AuthTest extends RequestSpecification {
 			invalid                                 | errorDetail
 			'a.b.c'                                 | 'Invalid unsecured/JWS/JWE header: Invalid JSON: Unexpected token  at position 0.'
 			'.'                                     | 'Invalid unsecured/JWS/JWE header: Invalid JSON: Unexpected token  at position 0.'
-			'a1.b.c.d'                              | 'Invalid unsecured/JWS/JWE header: Invalid JSON: Unexpected token k at position 1.'
-			'a2a.b'                                 | 'Invalid unsecured/JWS/JWE header: Invalid JSON: Unexpected token kf at position 2.'
+			'a1.b.c.d'                              | 'Invalid unsecured/JWS/JWE header: Invalid JSON: Unexpected token  at position 1.'
+			'a2a.b'                                 | 'Invalid unsecured/JWS/JWE header: Invalid JSON: Unexpected token  at position 2.'
 			'eyJ.eyJ.123'                           | 'Invalid unsecured/JWS/JWE header: Invalid JSON: Unexpected End Of File position 2: null'
 			'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzUxMiJ9.' | 'Invalid serialized unsecured/JWS/JWE object: Missing second delimiter'
 			'0'                                     | 'Invalid JWT serialization: Missing dot delimiter(s)'
 
 			"X$token"                               | 'Invalid unsecured/JWS/JWE header: Invalid JSON: Unexpected character (]) at position 0.'
 			"$token.$token"                         | 'Invalid serialized unsecured/JWS/JWE object: Too many part delimiters'
-			"e$token"                               | 'Invalid token'
+			"e$token"                               | 'Invalid unsecured/JWS/JWE header: Invalid JSON: Unexpected token  at position 72.'
 			"$token."                               | 'Invalid serialized JWE object: Missing fourth delimiter'
 			"${token}3"                             | 'Signed JWT rejected: Invalid signature'
 			"$token$token"                          | 'Unexpected number of Base64URL parts, must be three'
 
-			"${token.replaceFirst(/\./, '')}"       | 'Invalid token'
+			"${token.replaceFirst(/\./, '')}"       | 'Invalid unsecured/JWS/JWE header: Invalid JSON: Unexpected token  at position 83.'
 			"${token.replaceFirst(/\./, '..')}"     | 'Invalid serialized JWE object: Missing fourth delimiter'
 			"${token.replaceFirst(/\./, '.X')}"     | 'Malformed payload'
 	}

--- a/src/test/groovy/org/sharesquare/hub/endpoints/RequestSpecification.groovy
+++ b/src/test/groovy/org/sharesquare/hub/endpoints/RequestSpecification.groovy
@@ -1,0 +1,156 @@
+package org.sharesquare.hub.endpoints
+
+import static org.springframework.http.HttpHeaders.AUTHORIZATION
+import static org.springframework.http.HttpHeaders.CONTENT_TYPE
+import static org.springframework.http.MediaType.APPLICATION_FORM_URLENCODED
+import static org.springframework.http.MediaType.APPLICATION_JSON
+import static org.springframework.http.MediaType.APPLICATION_JSON_UTF8
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print
+
+import org.sharesquare.model.Offer
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.test.web.servlet.MockMvc
+
+import com.fasterxml.jackson.databind.ObjectMapper
+
+import groovyx.net.http.RESTClient
+import spock.lang.Specification
+
+@AutoConfigureMockMvc
+@WebMvcTest
+class RequestSpecification extends Specification {
+
+	@Autowired
+	private MockMvc mvc
+
+	@Autowired
+	ObjectMapper objectMapper
+
+	@Value("\${auth.server.token.uri}")
+	private String tokenUri;
+
+	@Value("\${auth.server.client.id}")
+	private String clientId;
+
+	@Value("\${auth.server.client.secret}")
+	private String clientSecret;
+
+	@Value("\${auth.server.client.not.in.scope.id}")
+	private String clientNotInScopeId;
+
+	@Value("\${auth.server.client.not.in.scope.secret}")
+	private String clientNotInScopeSecret;
+
+	protected static final uri = '/offers'
+
+	private static final defaultOffer = '{}'
+
+	def authServerResponse(id = clientId, secret = clientSecret) {
+		(new RESTClient(tokenUri))
+				.post(body: [client_id:     id,
+					         client_secret: secret,
+					         grant_type :   'client_credentials'],
+					  requestContentType: APPLICATION_FORM_URLENCODED)
+	}
+
+	def accessToken() {
+		authServerResponse().data.access_token
+	}
+
+	def accessTokenNotInScope() {
+		authServerResponse(clientNotInScopeId, clientNotInScopeSecret).data.access_token
+	}
+
+	def doPost(requestBody, mediaType = APPLICATION_JSON) {
+		mvc.perform(
+				post(uri)
+					.header(AUTHORIZATION, "Bearer ${accessToken()}")
+					.contentType(mediaType)
+					.content(requestBody)
+			)
+			.andDo(print())
+			.andReturn()
+			.response
+	}
+
+	def doUTF8Post(requestBody, mediaType = APPLICATION_JSON) {
+		mvc.perform(
+				post(uri)
+					.header(AUTHORIZATION, "Bearer ${accessToken()}")
+					.contentType(mediaType)
+					.content(requestBody)
+					.accept(APPLICATION_JSON_UTF8)
+			)
+			.andDo(print())
+			.andReturn()
+			.response
+	}
+
+	def doPostWithAuthHeaderValue(value) {
+		mvc.perform(
+				post(uri)
+					.header(AUTHORIZATION, value)
+					.contentType(APPLICATION_JSON)
+					.content(defaultOffer)
+			)
+			.andDo(print())
+			.andReturn()
+			.response
+	}
+
+	def doPostWithAuthHeaderKey(key) {
+		mvc.perform(
+				post(uri)
+					.header(key, "Bearer ${accessToken()}")
+					.contentType(APPLICATION_JSON)
+					.content(defaultOffer)
+			)
+			.andDo(print())
+			.andReturn()
+			.response
+	}
+
+	def doPostWithoutAuthHeader() {
+		mvc.perform(
+				post(uri)
+					.contentType(APPLICATION_JSON)
+					.content(defaultOffer)
+			)
+			.andDo(print())
+			.andReturn()
+			.response
+	}
+
+	def fromJson(content, valueType = Offer) {
+		objectMapper.readValue(content, valueType)
+	}
+
+	def toJson(object) {
+		objectMapper.writer().withDefaultPrettyPrinter().writeValueAsString(object);
+	}
+
+	void resultIs(response, httpStatus, mediaType = APPLICATION_JSON_VALUE) {
+		with (response) {
+			assert status                      == httpStatus.value
+			assert errorMessage                == null
+			assert headers[CONTENT_TYPE].value == mediaType
+			assert contentType                 == mediaType
+		}
+	}
+
+	void resultContentIs(responseContent, httpStatus, expectedMessage = null) {
+		with (responseContent) {
+			assert status == httpStatus.value
+			assert error  == httpStatus.reasonPhrase
+			if (expectedMessage != null) {
+				assert message == expectedMessage
+			}
+			assert path == uri
+		}
+	}
+}

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -1,0 +1,18 @@
+#keycloak
+auth.server.domain=${SHARE2_AUTH_SERVER_DOMAIN:http://localhost:9080}
+auth.server.realm=${SHARE2_AUTH_SERVER_REALM:xxx}
+auth.server.scope=${SHARE2_AUTH_SERVER_SCOPE:xxx}
+
+spring.security.oauth2.resourceserver.jwt.jwk-set-uri=${auth.server.domain}/auth/realms/${auth.server.realm}/protocol/openid-connect/certs
+auth.server.issuer.uri=${auth.server.domain}/auth/realms/${auth.server.realm}
+auth.server.token.uri=${auth.server.domain}/auth/realms/${auth.server.realm}/protocol/openid-connect/token
+
+auth.server.client.id= ${SHARE2_AUTH_SERVER_CLIENT_ID:xxx}
+auth.server.client.secret= ${SHARE2_AUTH_SERVER_CLIENT_SECRET:xxx}
+
+auth.server.client.not.in.scope.id= ${SHARE2_AUTH_SERVER_CLIENT_NOT_IN_SCOPE_ID:xxx}
+auth.server.client.not.in.scope.secret= ${SHARE2_AUTH_SERVER_CLIENT_NOT_IN_SCOPE_SECRET:xxx}
+
+token.expired=xxx
+
+logging.level.org.springframework.security=DEBUG


### PR DESCRIPTION
If the authorization fails, the application sends a `401` for wrong authorization details and a `403` for not allowed along with the reason in an error message. Swagger documentation can be reached without authorization.

Tests are included.