### PR TITLE
Implementation for the DELETE /offers/{id} endpoint

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -87,10 +87,9 @@ dependencies {
 	testImplementation 'org.springframework.security:spring-security-test'
 	testImplementation 'org.codehaus.groovy:groovy:3.0.4'
 	testImplementation 'org.codehaus.groovy:groovy-all:3.0.4'
-	testImplementation 'org.spockframework:spock-core:2.0-M3-groovy-3.0'
 	testImplementation 'org.spockframework:spock-spring:2.0-M3-groovy-3.0'
 	testImplementation 'org.codehaus.groovy.modules.http-builder:http-builder:0.7.1'
-	testImplementation 'com.athaydes:spock-reports:1.7.1'
+	testImplementation 'com.athaydes:spock-reports:2.0-RC2'
 }
 
 test {

--- a/src/main/java/org/sharesquare/hub/HubMain.java
+++ b/src/main/java/org/sharesquare/hub/HubMain.java
@@ -1,12 +1,15 @@
 package org.sharesquare.hub;
 
 
+import org.sharesquare.hub.configuration.SystemConfiguration;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.ComponentScan;
 
 @SpringBootApplication
 @ComponentScan({"org.sharesquare"})
+@EnableConfigurationProperties(SystemConfiguration.class)
 public class HubMain {
 
     public static void main(String[] args) {

--- a/src/main/java/org/sharesquare/hub/endpoints/Offers.java
+++ b/src/main/java/org/sharesquare/hub/endpoints/Offers.java
@@ -61,7 +61,7 @@ public class Offers {
         if(offerSanitizer.isIdValid(id)) {
             final Optional<Offer> offer = offerRepository.findById(id);
             if(offer.isPresent()) {
-                return ResponseEntity.ok().body(offer.get());
+                return ResponseEntity.ok(offer.get());
             }else{
                 return ResponseEntity.notFound().build();
             }

--- a/src/main/java/org/sharesquare/hub/endpoints/Offers.java
+++ b/src/main/java/org/sharesquare/hub/endpoints/Offers.java
@@ -122,8 +122,7 @@ public class Offers {
     @Operation(description = "Delete an Offer")
     @ApiResponse(responseCode = "204", description = "No content success")
     @ApiResponse(responseCode = "404", description = "Offer doesn't exist")
-    @ApiResponse(responseCode = "400", description = "Path variable Offer id is invalid")
-    @ApiResponse(responseCode = "405", description = "Path variable Offer id is missing")
+    @ApiResponse(responseCode = "400", description = "Path variable Offer id is invalid or missing")
     @DeleteMapping(path = "/offers/{id}")
     public ResponseEntity<Void> deleteOffer(@PathVariable final UUID id) {
     	if (offerService.deleteOffer(id)) {

--- a/src/main/java/org/sharesquare/hub/endpoints/Offers.java
+++ b/src/main/java/org/sharesquare/hub/endpoints/Offers.java
@@ -1,6 +1,9 @@
 package org.sharesquare.hub.endpoints;
 
 
+import static org.springframework.http.HttpStatus.NO_CONTENT;
+import static org.springframework.http.HttpStatus.NOT_FOUND;
+
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -25,6 +28,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import java.util.Optional;
+import java.util.UUID;
 
 import javax.validation.Valid;
 
@@ -120,10 +124,10 @@ public class Offers {
     @ApiResponse(description = "Malformed Data", responseCode = "422", content = @Content)
     @ApiResponse(description = "Entity Not Found", responseCode = "404", content = @Content)
     @DeleteMapping(path = "/offers/{id}", produces = MediaType.APPLICATION_JSON_VALUE, consumes = MediaType.APPLICATION_JSON_VALUE)
-    public ResponseEntity<Offer> deleteOffer(@PathVariable final String id){
-
-        return ResponseEntity.ok().body(null);
+    public ResponseEntity<Void> deleteOffer(@PathVariable final UUID id) {
+    	if (offerService.deleteOffer(id)) {
+    		return new ResponseEntity<>(NO_CONTENT);
+    	}
+    	return new ResponseEntity<>(NOT_FOUND);
     }
-
 }
-

--- a/src/main/java/org/sharesquare/hub/endpoints/Offers.java
+++ b/src/main/java/org/sharesquare/hub/endpoints/Offers.java
@@ -32,6 +32,8 @@ import java.util.UUID;
 
 import javax.validation.Valid;
 
+@ApiResponse(responseCode = "401", description = "Wrong client authorization", content = @Content)
+@ApiResponse(responseCode = "403", description = "Client not allowed", content = @Content)
 @RestController
 public class Offers {
 	
@@ -68,11 +70,9 @@ public class Offers {
     }
 
     @Operation(description = "Add a new Offer")
-    @ApiResponse(responseCode = "201", description = "Success", content = @Content)
-    @ApiResponse(responseCode = "400", description = "Wrong data input")
-    @ApiResponse(responseCode = "415", description = "Wrong format")
-    @ApiResponse(responseCode = "401", description = "Wrong client authorization")
-    @ApiResponse(responseCode = "403", description = "Client not allowed")
+    @ApiResponse(responseCode = "201", description = "Success")
+    @ApiResponse(responseCode = "400", description = "Wrong data input", content = @Content)
+    @ApiResponse(responseCode = "415", description = "Wrong format", content = @Content)
     @PostMapping(path = "/offers", produces = MediaType.APPLICATION_JSON_VALUE, consumes = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<Offer> createOffer(@Valid @RequestBody Offer offer) {
 
@@ -120,10 +120,11 @@ public class Offers {
     }
 
     @Operation(description = "Delete an Offer")
-    @ApiResponse(description = "Successful operation", responseCode = "200")
-    @ApiResponse(description = "Malformed Data", responseCode = "422", content = @Content)
-    @ApiResponse(description = "Entity Not Found", responseCode = "404", content = @Content)
-    @DeleteMapping(path = "/offers/{id}", produces = MediaType.APPLICATION_JSON_VALUE, consumes = MediaType.APPLICATION_JSON_VALUE)
+    @ApiResponse(responseCode = "204", description = "No content success")
+    @ApiResponse(responseCode = "404", description = "Offer doesn't exist")
+    @ApiResponse(responseCode = "400", description = "Path variable Offer id is invalid")
+    @ApiResponse(responseCode = "405", description = "Path variable Offer id is missing")
+    @DeleteMapping(path = "/offers/{id}")
     public ResponseEntity<Void> deleteOffer(@PathVariable final UUID id) {
     	if (offerService.deleteOffer(id)) {
     		return new ResponseEntity<>(NO_CONTENT);

--- a/src/main/java/org/sharesquare/hub/endpoints/Registry.java
+++ b/src/main/java/org/sharesquare/hub/endpoints/Registry.java
@@ -1,9 +1,9 @@
 package org.sharesquare.hub.endpoints;
 
 
-import org.sharesquare.model.Offer;
 import org.sharesquare.repository.IRepository;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -16,6 +16,7 @@ import java.util.Optional;
 @RestController
 public class Registry {
 
+	@Qualifier("createConnectorRepo")
     @Autowired
     IRepository<Connector> connectorRepo;
 

--- a/src/main/java/org/sharesquare/hub/endpoints/Registry.java
+++ b/src/main/java/org/sharesquare/hub/endpoints/Registry.java
@@ -16,7 +16,7 @@ import java.util.Optional;
 @RestController
 public class Registry {
 
-	@Qualifier("createConnectorRepo")
+    @Qualifier("createConnectorRepo")
     @Autowired
     IRepository<Connector> connectorRepo;
 

--- a/src/main/java/org/sharesquare/hub/exception/OfferResponseEntityExceptionHandler.java
+++ b/src/main/java/org/sharesquare/hub/exception/OfferResponseEntityExceptionHandler.java
@@ -107,7 +107,8 @@ public class OfferResponseEntityExceptionHandler {
 		String message = ex.getMessage();
 		HttpStatus httpStatus = METHOD_NOT_ALLOWED;
 		HttpServletRequest httpServletRequest = ((ServletWebRequest) request).getRequest();
-		if (httpServletRequest.getMethod().equals("DELETE") && httpServletRequest.getRequestURI().equals("/offers/")) {
+		if (httpServletRequest.getMethod().equals("DELETE")
+				&& httpServletRequest.getRequestURI().equals("/offers/")) {
 			message = "Required path variable Offer id is missing";
 			httpStatus = BAD_REQUEST;
 		}

--- a/src/main/java/org/sharesquare/hub/exception/OfferResponseEntityExceptionHandler.java
+++ b/src/main/java/org/sharesquare/hub/exception/OfferResponseEntityExceptionHandler.java
@@ -6,6 +6,7 @@ import static org.sharesquare.hub.exception.ErrorMessage.OFFER_IS_EMPTY;
 import static org.sharesquare.hub.exception.ErrorMessage.OFFER_NOT_VALID;
 import static org.sharesquare.hub.exception.ErrorMessage.REQUEST_BODY_IS_EMPTY;
 import static org.springframework.http.HttpStatus.BAD_REQUEST;
+import static org.springframework.http.HttpStatus.METHOD_NOT_ALLOWED;
 import static org.springframework.http.HttpStatus.UNSUPPORTED_MEDIA_TYPE;
 
 import java.util.List;
@@ -18,10 +19,12 @@ import org.springframework.util.CollectionUtils;
 import org.springframework.validation.BindingResult;
 import org.springframework.validation.FieldError;
 import org.springframework.web.HttpMediaTypeNotSupportedException;
+import org.springframework.web.HttpRequestMethodNotSupportedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.context.request.WebRequest;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 
 import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.databind.exc.InvalidFormatException;
@@ -60,7 +63,7 @@ public class OfferResponseEntityExceptionHandler {
 		} else if (message.startsWith(REQUEST_BODY_IS_EMPTY)) {
 			message = OFFER_IS_EMPTY;
 		}
-		log.info("Wrong user input: " + message);
+		log.info("Wrong client request (http message not readable): " + message);
 		return new ResponseEntity<>(new ResponseError(BAD_REQUEST, message, request), BAD_REQUEST);
 	}
 
@@ -75,13 +78,29 @@ public class OfferResponseEntityExceptionHandler {
 				message = String.format("%s Value '%s' not excepted.", e.getDefaultMessage(), e.getRejectedValue());
 			}
 		}
-		log.info("Wrong user input: " + message);
+		log.info("Wrong client request (method argument not valid): " + message);
+		return new ResponseEntity<>(new ResponseError(BAD_REQUEST, message, request), BAD_REQUEST);
+	}
+
+	@ExceptionHandler(MethodArgumentTypeMismatchException.class)
+	public ResponseEntity<Object> handleMethodArgumentTypeMismatch(MethodArgumentTypeMismatchException ex, WebRequest request) {
+		String message = ex.getMessage();
+		if (ex.getCause() instanceof IllegalArgumentException) {
+			message = String.format("Type mismatch for path variable: %s", ((IllegalArgumentException) ex.getCause()).getMessage());
+		}
+		log.info("Wrong client request (method argument type mismatch): " + message);
 		return new ResponseEntity<>(new ResponseError(BAD_REQUEST, message, request), BAD_REQUEST);
 	}
 
 	@ExceptionHandler(HttpMediaTypeNotSupportedException.class)
 	public ResponseEntity<Object> handleHttpMediaTypeNotSupported(HttpMediaTypeNotSupportedException ex, WebRequest request) {
-		log.info("Wrong user input: " + ex.getMessage());
+		log.info("Wrong client request (http media type not supported): " + ex.getMessage());
 		return new ResponseEntity<>(new ResponseError(UNSUPPORTED_MEDIA_TYPE, ex.getMessage(), request), UNSUPPORTED_MEDIA_TYPE);
+	}
+
+	@ExceptionHandler(HttpRequestMethodNotSupportedException.class)
+	public ResponseEntity<Object> handleHttpRequestMethodNotSupported(HttpRequestMethodNotSupportedException ex, WebRequest request) {
+		log.info("Wrong client request (http request method not supported): " + ex.getMessage());
+		return new ResponseEntity<>(new ResponseError(METHOD_NOT_ALLOWED, ex.getMessage(), request), METHOD_NOT_ALLOWED);
 	}
 }

--- a/src/main/java/org/sharesquare/hub/service/OfferService.java
+++ b/src/main/java/org/sharesquare/hub/service/OfferService.java
@@ -45,5 +45,5 @@ public class OfferService {
     		return true;
     	}
     	return false;
-	}
+    }
 }

--- a/src/main/java/org/sharesquare/hub/service/OfferService.java
+++ b/src/main/java/org/sharesquare/hub/service/OfferService.java
@@ -38,4 +38,12 @@ public class OfferService {
     //TODO: implement CRUD operations
     //TODO: implement findMany (call through repository)
 
+    public boolean deleteOffer(UUID id) {
+    	String idString = id.toString();
+    	if (offerRepository.findById(idString).isPresent()) {
+    		offerRepository.deleteById(idString);
+    		return true;
+    	}
+    	return false;
+	}
 }

--- a/src/main/java/org/sharesquare/repository/IRepository.java
+++ b/src/main/java/org/sharesquare/repository/IRepository.java
@@ -18,6 +18,8 @@ public interface IRepository<T extends IShareSquareObject> {
 
     Optional<T> delete(T data);
 
+    public void deleteById(String id);
+
     Optional<T> findById(String id);
 
     Page<T> findMany(T searchData, Pageable pageable);

--- a/src/main/java/org/sharesquare/repository/SimpleInMemoryRepository.java
+++ b/src/main/java/org/sharesquare/repository/SimpleInMemoryRepository.java
@@ -42,6 +42,11 @@ public class SimpleInMemoryRepository<T extends IShareSquareObject> implements I
     }
 
     @Override
+    public void deleteById(String id) {
+    	inMemData.remove(id);
+    }
+
+    @Override
     public Optional<T> findById(String id) {
         return Optional.ofNullable(inMemData.get(id));
     }

--- a/src/test/groovy/org/sharesquare/hub/endpoints/AuthTest.groovy
+++ b/src/test/groovy/org/sharesquare/hub/endpoints/AuthTest.groovy
@@ -1,6 +1,6 @@
 package org.sharesquare.hub.endpoints
 
-import static org.sharesquare.hub.endpoints.OfferUtil.postUri
+import static org.sharesquare.hub.endpoints.OfferUtil.offersUri
 import static org.springframework.http.HttpHeaders.CONTENT_TYPE
 import static org.springframework.http.HttpHeaders.WWW_AUTHENTICATE
 import static org.springframework.http.HttpStatus.FORBIDDEN
@@ -41,7 +41,7 @@ class AuthTest extends RequestSpecification {
 
 	def "A request without authorization header should respond with status code 401 and a meaningful error message"() {
 		when:
-			final response = doPostWithoutAuthHeader(postUri)
+			final response = doPostWithoutAuthHeader(offersUri)
 
 		then:
 			resultIs(response, UNAUTHORIZED)
@@ -51,14 +51,14 @@ class AuthTest extends RequestSpecification {
 			final expectedMessage = 'Insufficient authentication: Full authentication is required to access this resource'
 
 		then:
-			resultContentIs(postUri, responseError, UNAUTHORIZED, expectedMessage)
+			resultContentIs(offersUri, responseError, UNAUTHORIZED, expectedMessage)
 	}
 
 	static final jwtError = 'An error occurred while attempting to decode the Jwt: '
 
 	def "A request with an invalid access token should respond with status code 401 and a meaningful error message"() {
 		when:
-			final response = doPostWithAuthHeaderValue(postUri, "Bearer $invalid")
+			final response = doPostWithAuthHeaderValue(offersUri, "Bearer $invalid")
 
 		then:
 			resultIs(response, UNAUTHORIZED)
@@ -68,7 +68,7 @@ class AuthTest extends RequestSpecification {
 			responseError.message = responseError.message.replaceFirst(/ token [^ ]* at /, ' token  at ')
 
 		then:
-			resultContentIs(postUri, responseError, UNAUTHORIZED, jwtError + errorDetail)
+			resultContentIs(offersUri, responseError, UNAUTHORIZED, jwtError + errorDetail)
 
 		where:
 			invalid                                 | errorDetail
@@ -96,7 +96,7 @@ class AuthTest extends RequestSpecification {
 
 	def "A request with a malformed or empty access token should respond with status code 401 and a meaningful error message in the response header"() {
 		when:
-			final response = doPostWithAuthHeaderValue(postUri, "Bearer $malformed")
+			final response = doPostWithAuthHeaderValue(offersUri, "Bearer $malformed")
 
 		then:
 			with (response) {
@@ -121,7 +121,7 @@ class AuthTest extends RequestSpecification {
 
 	def "A request with a malformed authorization header value should respond with status code 401 and a meaningful error message in the response header"() {
 		when:
-			final response = doPostWithAuthHeaderValue(postUri, value)
+			final response = doPostWithAuthHeaderValue(offersUri, value)
 
 		then:
 			with (response) {
@@ -143,7 +143,7 @@ class AuthTest extends RequestSpecification {
 
 	def "A request with an invalid or empty authorization header value should respond with status code 401 and a meaningful error message"() {
 		when:
-			final response = doPostWithAuthHeaderValue(postUri, value)
+			final response = doPostWithAuthHeaderValue(offersUri, value)
 
 		then:
 			resultIs(response, UNAUTHORIZED)
@@ -153,7 +153,7 @@ class AuthTest extends RequestSpecification {
 			final expectedMessage = 'Insufficient authentication: Full authentication is required to access this resource'
 
 		then:
-			resultContentIs(postUri, responseError, UNAUTHORIZED, expectedMessage)
+			resultContentIs(offersUri, responseError, UNAUTHORIZED, expectedMessage)
 
 		where:
 			value            | _
@@ -167,7 +167,7 @@ class AuthTest extends RequestSpecification {
 
 	def "A request with an invalid or empty authorization header key should respond with status code 401 and a meaningful error message"() {
 		when:
-			final response = doPostWithAuthHeaderKey(postUri, key)
+			final response = doPostWithAuthHeaderKey(offersUri, key)
 
 		then:
 			resultIs(response, UNAUTHORIZED)
@@ -177,7 +177,7 @@ class AuthTest extends RequestSpecification {
 			final expectedMessage = 'Insufficient authentication: Full authentication is required to access this resource'
 
 		then:
-			resultContentIs(postUri, responseError, UNAUTHORIZED, expectedMessage)
+			resultContentIs(offersUri, responseError, UNAUTHORIZED, expectedMessage)
 
 		where:
 			key              | _
@@ -190,7 +190,7 @@ class AuthTest extends RequestSpecification {
 
 	def "A request with an expired access token should respond with status code 401 and a meaningful error message"() {
 		when:
-			def response = doPostWithAuthHeaderValue(postUri, "Bearer $tokenExpired")
+			def response = doPostWithAuthHeaderValue(offersUri, "Bearer $tokenExpired")
 
 		then:
 			resultIs(response, UNAUTHORIZED)
@@ -201,12 +201,12 @@ class AuthTest extends RequestSpecification {
 			final expectedMessage = 'An error occurred while attempting to decode the Jwt: Jwt expired at '
 
 		then:
-			resultContentIs(postUri, responseError, UNAUTHORIZED, expectedMessage)
+			resultContentIs(offersUri, responseError, UNAUTHORIZED, expectedMessage)
 	}
 
 	def "A request with an access token not in the scope should respond with status code 403 and a meaningful error message"() {
 		when:
-			final response = doPostWithAuthHeaderValue(postUri, "Bearer ${accessTokenNotInScope()}")
+			final response = doPostWithAuthHeaderValue(offersUri, "Bearer ${accessTokenNotInScope()}")
 
 		then:
 			resultIs(response, FORBIDDEN)
@@ -215,6 +215,6 @@ class AuthTest extends RequestSpecification {
 			final responseError = fromJson(response.contentAsString, Map)
 
 		then:
-			resultContentIs(postUri, responseError, FORBIDDEN, 'Access is denied')
+			resultContentIs(offersUri, responseError, FORBIDDEN, 'Access is denied')
 	}
 }

--- a/src/test/groovy/org/sharesquare/hub/endpoints/OfferDeleteRequestTest.groovy
+++ b/src/test/groovy/org/sharesquare/hub/endpoints/OfferDeleteRequestTest.groovy
@@ -2,7 +2,6 @@ package org.sharesquare.hub.endpoints
 
 import static org.sharesquare.hub.endpoints.OfferUtil.offersUri
 import static org.springframework.http.HttpStatus.BAD_REQUEST
-import static org.springframework.http.HttpStatus.METHOD_NOT_ALLOWED
 import static org.springframework.http.HttpStatus.NOT_FOUND
 import static org.springframework.http.HttpStatus.NO_CONTENT
 

--- a/src/test/groovy/org/sharesquare/hub/endpoints/OfferDeleteRequestTest.groovy
+++ b/src/test/groovy/org/sharesquare/hub/endpoints/OfferDeleteRequestTest.groovy
@@ -1,0 +1,69 @@
+package org.sharesquare.hub.endpoints
+
+import static org.sharesquare.hub.endpoints.OfferUtil.offersUri
+import static org.springframework.http.HttpStatus.BAD_REQUEST
+import static org.springframework.http.HttpStatus.METHOD_NOT_ALLOWED
+import static org.springframework.http.HttpStatus.NOT_FOUND
+import static org.springframework.http.HttpStatus.NO_CONTENT
+
+import spock.lang.Issue
+
+@Issue("#11")
+class OfferDeleteRequestTest extends RequestSpecification {
+
+	def "A delete request with an existing id should respond with status code 204"() {
+		when:
+			final uuid = fromJson(doPost(offersUri, defaultOffer).contentAsString).id
+			final response = doDelete("$offersUri/$uuid")
+
+		then:
+			response.status == NO_CONTENT.value
+	}
+
+	def "A delete request with a not existing id should respond with status code 404"() {
+		given:
+			final uuid = UUID.randomUUID()
+
+		when:
+			final response = doDelete("$offersUri/$uuid")
+
+		then:
+			response.status == NOT_FOUND.value
+	}
+
+	def "A delete request with an invalid UUID should respond with status code 400 and a meaningful error message"() {
+		given:
+			final uuid = 'invalid'
+
+		when:
+			final response = doDelete("$offersUri/$uuid")
+
+		then:
+			resultIs(response, BAD_REQUEST)
+
+		when:
+			final responseError = fromJson(response.contentAsString, Map)
+			final expectedMessage = "Type mismatch for path variable: Invalid UUID string: $uuid"
+
+		then:
+			resultContentIs("$offersUri/$uuid", responseError, BAD_REQUEST, expectedMessage)
+	}
+
+	def "A delete request with an empty id should respond with status code 405 and a meaningful error message"() {
+		given:
+			final uuid = ''
+
+		when:
+			final response = doDelete("$offersUri/$uuid")
+
+		then:
+			resultIs(response, METHOD_NOT_ALLOWED)
+
+		when:
+			final responseError = fromJson(response.contentAsString, Map)
+			final expectedMessage = "Request method 'DELETE' not supported"
+
+		then:
+			resultContentIs("$offersUri/$uuid", responseError, METHOD_NOT_ALLOWED, expectedMessage)
+	}
+}

--- a/src/test/groovy/org/sharesquare/hub/endpoints/OfferDeleteRequestTest.groovy
+++ b/src/test/groovy/org/sharesquare/hub/endpoints/OfferDeleteRequestTest.groovy
@@ -43,7 +43,7 @@ class OfferDeleteRequestTest extends RequestSpecification {
 		then:
 			resultContentIs("$offersUri/$uuid", responseError, BAD_REQUEST, expectedMessage)
 
-			where:
+		where:
 			uuid      | expectedMessage
 			'invalid' | "Type mismatch for path variable: Invalid UUID string: $uuid"
 			''        | 'Required path variable Offer id is missing'

--- a/src/test/groovy/org/sharesquare/hub/endpoints/OfferDeleteRequestTest.groovy
+++ b/src/test/groovy/org/sharesquare/hub/endpoints/OfferDeleteRequestTest.groovy
@@ -31,10 +31,7 @@ class OfferDeleteRequestTest extends RequestSpecification {
 			response.status == NOT_FOUND.value
 	}
 
-	def "A delete request with an invalid UUID should respond with status code 400 and a meaningful error message"() {
-		given:
-			final uuid = 'invalid'
-
+	def "A delete request with an invalid UUID or an empty id should respond with status code 400 and a meaningful error message"() {
 		when:
 			final response = doDelete("$offersUri/$uuid")
 
@@ -43,27 +40,13 @@ class OfferDeleteRequestTest extends RequestSpecification {
 
 		when:
 			final responseError = fromJson(response.contentAsString, Map)
-			final expectedMessage = "Type mismatch for path variable: Invalid UUID string: $uuid"
 
 		then:
 			resultContentIs("$offersUri/$uuid", responseError, BAD_REQUEST, expectedMessage)
-	}
 
-	def "A delete request with an empty id should respond with status code 405 and a meaningful error message"() {
-		given:
-			final uuid = ''
-
-		when:
-			final response = doDelete("$offersUri/$uuid")
-
-		then:
-			resultIs(response, METHOD_NOT_ALLOWED)
-
-		when:
-			final responseError = fromJson(response.contentAsString, Map)
-			final expectedMessage = "Request method 'DELETE' not supported"
-
-		then:
-			resultContentIs("$offersUri/$uuid", responseError, METHOD_NOT_ALLOWED, expectedMessage)
+			where:
+			uuid      | expectedMessage
+			'invalid' | "Type mismatch for path variable: Invalid UUID string: $uuid"
+			''        | 'Required path variable Offer id is missing'
 	}
 }

--- a/src/test/groovy/org/sharesquare/hub/endpoints/OfferPostRequestTest.groovy
+++ b/src/test/groovy/org/sharesquare/hub/endpoints/OfferPostRequestTest.groovy
@@ -1,6 +1,6 @@
 package org.sharesquare.hub.endpoints
 
-import static org.sharesquare.hub.endpoints.OfferUtil.postUri
+import static org.sharesquare.hub.endpoints.OfferUtil.offersUri
 import static org.sharesquare.hub.endpoints.OfferUtil.userId
 import static org.springframework.http.HttpStatus.BAD_REQUEST
 import static org.springframework.http.HttpStatus.CREATED
@@ -22,7 +22,7 @@ class OfferPostRequestTest extends RequestSpecification {
 		when:
 			// StackOverflowError when using groovy.json.JsonOutput.toJson with java.time.ZoneId
 			// https://issues.apache.org/jira/browse/GROOVY-7682
-			final response = doPost(postUri, toJson(offer))
+			final response = doPost(offersUri, toJson(offer))
 
 		then:
 			resultIs(response, CREATED)
@@ -46,7 +46,7 @@ class OfferPostRequestTest extends RequestSpecification {
 			final emptyRequestBody = ''
 
 		when:
-			final response = doPost(postUri, emptyRequestBody)
+			final response = doPost(offersUri, emptyRequestBody)
 
 		then:
 			resultIs(response, BAD_REQUEST)
@@ -56,7 +56,7 @@ class OfferPostRequestTest extends RequestSpecification {
 			final expectedMessage = 'Required request body for Offer is missing'
 
 		then:
-			resultContentIs(postUri, responseError, BAD_REQUEST, expectedMessage)
+			resultContentIs(offersUri, responseError, BAD_REQUEST, expectedMessage)
 	}
 
 	def "A post request with invalid JSON should respond with status code 400 and a meaningful error message"() {
@@ -64,7 +64,7 @@ class OfferPostRequestTest extends RequestSpecification {
 			final invalidJson = '{.'
 
 		when:
-			final response = doPost(postUri, invalidJson)
+			final response = doPost(offersUri, invalidJson)
 
 		then:
 			resultIs(response, BAD_REQUEST)
@@ -74,7 +74,7 @@ class OfferPostRequestTest extends RequestSpecification {
 			final expectedMessage = "Invalid request body for Offer. JSON parse error: Unexpected character ('.' (code 46)): was expecting double-quote to start field name"
 
 		then:
-			resultContentIs(postUri, responseError, BAD_REQUEST, expectedMessage)
+			resultContentIs(offersUri, responseError, BAD_REQUEST, expectedMessage)
 	}
 
 	def "A post request with a wrong field type in the body should respond with status code 400 and a meaningful error message"() {
@@ -82,7 +82,7 @@ class OfferPostRequestTest extends RequestSpecification {
 			final invalidOffer = [userId: []]
 
 		when:
-			final response = doPost(postUri, toJson(invalidOffer))
+			final response = doPost(offersUri, toJson(invalidOffer))
 
 		then:
 			resultIs(response, BAD_REQUEST)
@@ -91,9 +91,9 @@ class OfferPostRequestTest extends RequestSpecification {
 			final responseError = fromJson(response.contentAsString, Map)
 
 		then:
-			resultContentIs(postUri, responseError, BAD_REQUEST)
-				// depending on spring boot version
-				(responseError.message == "Invalid JSON input for Offer in field 'userId': Cannot deserialize instance of `java.lang.String` out of START_ARRAY token"
+			resultContentIs(offersUri, responseError, BAD_REQUEST)
+			// depending on spring boot version
+			(responseError.message == "Invalid JSON input for Offer in field 'userId': Cannot deserialize instance of `java.lang.String` out of START_ARRAY token"
 				|| responseError.message == "JSON parse error for Offer in field 'userId': Cannot deserialize instance of `java.lang.String` out of START_ARRAY token")
 	}
 
@@ -102,7 +102,7 @@ class OfferPostRequestTest extends RequestSpecification {
 			final offerAsXml = "<offer><$userId>2</$userId></offer>"
 
 		when:
-			final response = doPost(postUri, offerAsXml, TEXT_XML)
+			final response = doPost(offersUri, offerAsXml, TEXT_XML)
 
 		then:
 			resultIs(response, UNSUPPORTED_MEDIA_TYPE)
@@ -112,7 +112,7 @@ class OfferPostRequestTest extends RequestSpecification {
 			final expectedMessage = "Content type 'text/xml' not supported"
 
 		then:
-			resultContentIs(postUri, responseError, UNSUPPORTED_MEDIA_TYPE, expectedMessage)
+			resultContentIs(offersUri, responseError, UNSUPPORTED_MEDIA_TYPE, expectedMessage)
 	}
 
 	def "A post request with umlaut should work"() {
@@ -120,7 +120,7 @@ class OfferPostRequestTest extends RequestSpecification {
 			def offer = new Offer(userId: '\u00fc') // ue
 
 		when:
-			final response = doUTF8Post(postUri, toJson(offer))
+			final response = doUTF8Post(offersUri, toJson(offer))
 
 		then:
 			resultIs(response, CREATED, APPLICATION_JSON_UTF8_VALUE)
@@ -145,7 +145,7 @@ class OfferPostRequestTest extends RequestSpecification {
 				           startDate: '2013-12-20']
 
 		when:
-			final response = doPost(postUri, toJson(offer))
+			final response = doPost(offersUri, toJson(offer))
 
 		then:
 			resultIs(response, CREATED)
@@ -169,7 +169,7 @@ class OfferPostRequestTest extends RequestSpecification {
 			final offer = [startTimezone: 'Europe/Paris']
 
 		when:
-			final response = doPost(postUri, toJson(offer))
+			final response = doPost(offersUri, toJson(offer))
 
 		then:
 			resultIs(response, CREATED)
@@ -187,7 +187,7 @@ class OfferPostRequestTest extends RequestSpecification {
 			final invalidOffer = [startTime: 'x']
 
 		when:
-			final response = doPost(postUri, toJson(invalidOffer))
+			final response = doPost(offersUri, toJson(invalidOffer))
 
 		then:
 			resultIs(response, BAD_REQUEST)
@@ -196,8 +196,8 @@ class OfferPostRequestTest extends RequestSpecification {
 			final responseError = fromJson(response.contentAsString, Map)
 
 		then:
-			resultContentIs(postUri, responseError, BAD_REQUEST)
-				responseError.message.startsWith("JSON parse error for Offer in field 'startTime'")
+			resultContentIs(offersUri, responseError, BAD_REQUEST)
+			responseError.message.startsWith("JSON parse error for Offer in field 'startTime'")
 	}
 
 	def "A post request with an invalid startDate should respond with status code 400 and a meaningful error message"() {
@@ -205,7 +205,7 @@ class OfferPostRequestTest extends RequestSpecification {
 			final invalidOffer = [startDate: ',']
 
 		when:
-			final response = doPost(postUri, toJson(invalidOffer))
+			final response = doPost(offersUri, toJson(invalidOffer))
 
 		then:
 			resultIs(response, BAD_REQUEST)
@@ -214,8 +214,8 @@ class OfferPostRequestTest extends RequestSpecification {
 			final responseError = fromJson(response.contentAsString, Map)
 
 		then:
-			resultContentIs(postUri, responseError, BAD_REQUEST)
-				responseError.message.startsWith("JSON parse error for Offer in field 'startDate'")
+			resultContentIs(offersUri, responseError, BAD_REQUEST)
+			responseError.message.startsWith("JSON parse error for Offer in field 'startDate'")
 	}
 
 	def "A post request with an invalid startTimezone should respond with status code 400 and a meaningful error message"() {
@@ -223,7 +223,7 @@ class OfferPostRequestTest extends RequestSpecification {
 			final invalidOffer = [startTimezone: '1 7']
 
 		when:
-			final response = doPost(postUri, toJson(invalidOffer))
+			final response = doPost(offersUri, toJson(invalidOffer))
 
 		then:
 			resultIs(response, BAD_REQUEST)
@@ -232,7 +232,7 @@ class OfferPostRequestTest extends RequestSpecification {
 			final responseError = fromJson(response.contentAsString, Map)
 
 		then:
-			resultContentIs(postUri, responseError, BAD_REQUEST)
-				responseError.message.startsWith("JSON parse error for Offer in field 'startTimezone'")
+			resultContentIs(offersUri, responseError, BAD_REQUEST)
+			responseError.message.startsWith("JSON parse error for Offer in field 'startTimezone'")
 	}
 }

--- a/src/test/groovy/org/sharesquare/hub/endpoints/OfferUtil.groovy
+++ b/src/test/groovy/org/sharesquare/hub/endpoints/OfferUtil.groovy
@@ -2,7 +2,7 @@ package org.sharesquare.hub.endpoints
 
 class OfferUtil {
 
-	protected static final postUri = '/offers'
+	protected static final offersUri = '/offers'
 
 	protected static final userId = 'userId'
 }

--- a/src/test/groovy/org/sharesquare/hub/endpoints/RequestSpecification.groovy
+++ b/src/test/groovy/org/sharesquare/hub/endpoints/RequestSpecification.groovy
@@ -6,6 +6,7 @@ import static org.springframework.http.MediaType.APPLICATION_FORM_URLENCODED
 import static org.springframework.http.MediaType.APPLICATION_JSON
 import static org.springframework.http.MediaType.APPLICATION_JSON_UTF8
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print
@@ -47,7 +48,7 @@ class RequestSpecification extends Specification {
 	@Value("\${auth.server.client.not.in.scope.secret}")
 	private String clientNotInScopeSecret;
 
-	private static final defaultOffer = '{}'
+	static final defaultOffer = '{}'
 
 	def authServerResponse(id = clientId, secret = clientSecret) {
 		(new RESTClient(tokenUri))
@@ -128,6 +129,16 @@ class RequestSpecification extends Specification {
 	def doGet(uri) {
 		mvc.perform(
 				get(uri)
+					.header(AUTHORIZATION, "Bearer ${accessToken()}")
+			)
+			.andDo(print())
+			.andReturn()
+			.response
+	}
+
+	def doDelete(uri) {
+		mvc.perform(
+				delete(uri)
 					.header(AUTHORIZATION, "Bearer ${accessToken()}")
 			)
 			.andDo(print())


### PR DESCRIPTION
Returns
* `204` if the Offer was deleted
* `404` if the Offer doesn't exist
* `400` for an invalid or empty Offer id and a error message in the response body

Test cases are included.