### PR TITLE
Implementation for the PUT /offers/{id} endpoint

### DIFF
--- a/src/main/java/org/sharesquare/hub/endpoints/Offers.java
+++ b/src/main/java/org/sharesquare/hub/endpoints/Offers.java
@@ -89,15 +89,13 @@ public class Offers {
     @ApiResponse(description = "Successful operation", responseCode = "202")
     @ApiResponse(description = "Malformed Data", responseCode = "422", content = @Content)
     @ApiResponse(description = "Entity Not Found", responseCode = "404", content = @Content)
-    @PutMapping(produces = MediaType.APPLICATION_JSON_VALUE, consumes = MediaType.APPLICATION_JSON_VALUE)
-    public ResponseEntity<Offer> updateOffer(@RequestBody Offer offer){
-
-        final Optional<Offer> result = offerRepository.update(offer);
-        if(result.isPresent()) {
-            return ResponseEntity.accepted().body(result.get());
-        }else{
-            return ResponseEntity.unprocessableEntity().build();
-        }
+    @PutMapping(path = "/{id}", produces = MediaType.APPLICATION_JSON_VALUE, consumes = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<Void> updateOffer(@PathVariable final UUID id,
+    		                                @Valid @RequestBody Offer offer) {
+    	if (offerService.updateOffer(id, offer)) {
+    		return ResponseEntity.ok(null);
+    	}
+    	return new ResponseEntity<>(NOT_FOUND);
     }
 
     @GetMapping(produces = MediaType.APPLICATION_JSON_VALUE, consumes = MediaType.APPLICATION_JSON_VALUE)

--- a/src/main/java/org/sharesquare/hub/endpoints/Offers.java
+++ b/src/main/java/org/sharesquare/hub/endpoints/Offers.java
@@ -62,7 +62,7 @@ public class Offers {
     	return new ResponseEntity<>(NOT_FOUND);
     }
 
-    @Operation(description = "Add a new Offer")
+    @Operation(description = "Add a new Offer using a generated id")
     @ApiResponse(responseCode = "201", description = "Success")
     @ApiResponse(responseCode = "400", description = "Wrong data input", content = @Content)
     @ApiResponse(responseCode = "415", description = "Wrong format", content = @Content)
@@ -85,10 +85,11 @@ public class Offers {
         }
     }
 
-    @Operation(description = "Update an Offer")
-    @ApiResponse(description = "Successful operation", responseCode = "202")
-    @ApiResponse(description = "Malformed Data", responseCode = "422", content = @Content)
-    @ApiResponse(description = "Entity Not Found", responseCode = "404", content = @Content)
+    @Operation(description = "Update an existing Offer")
+    @ApiResponse(responseCode = "200", description = "Success")
+    @ApiResponse(responseCode = "404", description = "Offer doesn't exist")
+    @ApiResponse(responseCode = "400", description = "Wrong data input")
+    @ApiResponse(responseCode = "415", description = "Wrong format")
     @PutMapping(path = "/{id}", produces = MediaType.APPLICATION_JSON_VALUE, consumes = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<Void> updateOffer(@PathVariable final UUID id,
     		                                @Valid @RequestBody Offer offer) {

--- a/src/main/java/org/sharesquare/hub/endpoints/Offers.java
+++ b/src/main/java/org/sharesquare/hub/endpoints/Offers.java
@@ -53,7 +53,7 @@ public class Offers {
     @ApiResponse(responseCode = "200", description = "Success")
     @ApiResponse(responseCode = "404", description = "Offer doesn't exist", content = @Content)
     @ApiResponse(responseCode = "400", description = "Path variable Offer id is invalid or missing", content = @Content)
-    @GetMapping(path="/{id}", produces = MediaType.APPLICATION_JSON_VALUE)
+    @GetMapping(path = "/{id}", produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<Offer> getOffer(@PathVariable final UUID id) {
     	final Offer offer = offerService.getOffer(id);
     	if (offer != null) {

--- a/src/main/java/org/sharesquare/hub/endpoints/Offers.java
+++ b/src/main/java/org/sharesquare/hub/endpoints/Offers.java
@@ -67,8 +67,7 @@ public class Offers {
     @ApiResponse(responseCode = "400", description = "Wrong data input", content = @Content)
     @ApiResponse(responseCode = "415", description = "Wrong format", content = @Content)
     @PostMapping(produces = MediaType.APPLICATION_JSON_VALUE, consumes = MediaType.APPLICATION_JSON_VALUE)
-    public ResponseEntity<Offer> createOffer(@Valid @RequestBody Offer offer) {
-
+    public ResponseEntity<Offer> addOffer(@Valid @RequestBody Offer offer) {
         final Optional<Offer> result = offerRepository.create(offer);
         if(result.isPresent()) {
         	return new ResponseEntity<>(result.get(), HttpStatus.CREATED);

--- a/src/main/java/org/sharesquare/hub/exception/OfferResponseEntityExceptionHandler.java
+++ b/src/main/java/org/sharesquare/hub/exception/OfferResponseEntityExceptionHandler.java
@@ -124,6 +124,7 @@ public class OfferResponseEntityExceptionHandler {
 	private boolean requestHasEmptyPathVariable(WebRequest request) {
 		HttpServletRequest httpServletRequest = ((ServletWebRequest) request).getRequest();
 		if ((httpServletRequest.getMethod().equals("GET")
+				|| httpServletRequest.getMethod().equals("PUT")
 				|| httpServletRequest.getMethod().equals("DELETE"))
 				&& httpServletRequest.getRequestURI().equals("/offers/")) {
 			return true;

--- a/src/main/java/org/sharesquare/hub/service/OfferService.java
+++ b/src/main/java/org/sharesquare/hub/service/OfferService.java
@@ -47,6 +47,15 @@ public class OfferService {
 		return null;
 	}
 
+    public boolean updateOffer(UUID id, Offer offer) {
+		offer.setId(id);
+		Optional<Offer> previousOffer = offerRepository.update(offer);
+		if (previousOffer.isPresent()) {
+			return true;
+		}
+		return false;
+	}
+
     public boolean deleteOffer(UUID id) {
     	String idString = id.toString();
     	if (offerRepository.findById(idString).isPresent()) {

--- a/src/main/java/org/sharesquare/repository/IRepository.java
+++ b/src/main/java/org/sharesquare/repository/IRepository.java
@@ -18,7 +18,7 @@ public interface IRepository<T extends IShareSquareObject> {
 
     Optional<T> delete(T data);
 
-    public void deleteById(String id);
+    void deleteById(String id);
 
     Optional<T> findById(String id);
 

--- a/src/main/java/org/sharesquare/repository/SimpleInMemoryRepository.java
+++ b/src/main/java/org/sharesquare/repository/SimpleInMemoryRepository.java
@@ -27,10 +27,7 @@ public class SimpleInMemoryRepository<T extends IShareSquareObject> implements I
 
     @Override
     public Optional<T> update(T data) {
-    	if (data.getId() != null) {
     		return Optional.ofNullable(inMemData.replace(data.getId().toString(),data));
-    	}
-    	return Optional.empty();
     }
 
     @Override

--- a/src/main/java/org/sharesquare/repository/SimpleInMemoryRepository.java
+++ b/src/main/java/org/sharesquare/repository/SimpleInMemoryRepository.java
@@ -4,7 +4,6 @@ import org.sharesquare.IShareSquareObject;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
-import org.springframework.stereotype.Service;
 
 import java.util.Collection;
 import java.util.List;
@@ -14,7 +13,6 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.stream.Collectors;
 
-@Service
 public class SimpleInMemoryRepository<T extends IShareSquareObject> implements IRepository<T> {
     ConcurrentMap<String, T> inMemData = new ConcurrentHashMap<>();
 

--- a/src/test/groovy/org/sharesquare/hub/endpoints/OfferDeleteRequestTest.groovy
+++ b/src/test/groovy/org/sharesquare/hub/endpoints/OfferDeleteRequestTest.groovy
@@ -12,14 +12,14 @@ class OfferDeleteRequestTest extends RequestSpecification {
 
 	def "A delete request with an existing id should work and respond with status code 204"() {
 		when:
-			final uuid = fromJson(doPost(offersUri, defaultOffer).contentAsString).id
-			final response = doDelete("$offersUri/$uuid")
+			final id = fromJson(doPost(offersUri, defaultOffer).contentAsString).id
+			final response = doDelete("$offersUri/$id")
 
 		then:
 			response.status == NO_CONTENT.value
 
 		when:
-			final getResponse = doGet("$offersUri/$uuid")
+			final getResponse = doGet("$offersUri/$id")
 
 		then:
 			getResponse.status == NOT_FOUND.value
@@ -27,16 +27,16 @@ class OfferDeleteRequestTest extends RequestSpecification {
 
 	def "A delete request with a not existing id should respond with status code 404"() {
 		given:
-			final uuid = UUID.randomUUID()
+			final id = UUID.randomUUID()
 
 		when:
-			final response = doDelete("$offersUri/$uuid")
+			final response = doDelete("$offersUri/$id")
 
 		then:
 			response.status == NOT_FOUND.value
 
 		when:
-			final getResponse = doGet("$offersUri/$uuid")
+			final getResponse = doGet("$offersUri/$id")
 
 		then:
 			getResponse.status == NOT_FOUND.value
@@ -44,7 +44,7 @@ class OfferDeleteRequestTest extends RequestSpecification {
 
 	def "A delete request with an invalid UUID or an empty id should respond with status code 400 and a meaningful error message"() {
 		when:
-			final response = doDelete("$offersUri/$uuid")
+			final response = doDelete("$offersUri/$id")
 
 		then:
 			resultIs(response, BAD_REQUEST)
@@ -53,17 +53,17 @@ class OfferDeleteRequestTest extends RequestSpecification {
 			final responseError = fromJson(response.contentAsString, Map)
 
 		then:
-			resultContentIs("$offersUri/$uuid", responseError, BAD_REQUEST, expectedMessage)
+			resultContentIs("$offersUri/$id", responseError, BAD_REQUEST, expectedMessage)
 
 		when:
-			final getResponse = doGet("$offersUri/$uuid")
+			final getResponse = doGet("$offersUri/$id")
 
 		then:
 			getResponse.status == BAD_REQUEST.value
 
 		where:
-			uuid      | expectedMessage
-			'invalid' | "Type mismatch for path variable: Invalid UUID string: $uuid"
+			id       | expectedMessage
+			'invalid' | "Type mismatch for path variable: Invalid UUID string: $id"
 			''        | 'Required path variable Offer id is missing'
 	}
 }

--- a/src/test/groovy/org/sharesquare/hub/endpoints/OfferGetRequestTest.groovy
+++ b/src/test/groovy/org/sharesquare/hub/endpoints/OfferGetRequestTest.groovy
@@ -12,8 +12,8 @@ class OfferGetRequestTest extends RequestSpecification {
 
 	def "A get request with an existing id should return the corresponding Offer along with status code 200"() {
 		when:
-			final uuid = fromJson(doPost(offersUri, defaultOffer).contentAsString).id
-			final response = doGet("$offersUri/$uuid")
+			final id = fromJson(doPost(offersUri, defaultOffer).contentAsString).id
+			final response = doGet("$offersUri/$id")
 
 		then:
 			resultIs(response, OK)
@@ -28,10 +28,10 @@ class OfferGetRequestTest extends RequestSpecification {
 
 	def "A get request with a not existing id should respond with status code 404"() {
 		given:
-			final uuid = UUID.randomUUID()
+			final id = UUID.randomUUID()
 
 		when:
-			final response = doGet("$offersUri/$uuid")
+			final response = doGet("$offersUri/$id")
 
 		then:
 			response.status == NOT_FOUND.value
@@ -39,7 +39,7 @@ class OfferGetRequestTest extends RequestSpecification {
 
 	def "A get request with an invalid UUID or an empty id should respond with status code 400 and a meaningful error message"() {
 		when:
-			final response = doGet("$offersUri/$uuid")
+			final response = doGet("$offersUri/$id")
 
 		then:
 			resultIs(response, BAD_REQUEST)
@@ -48,11 +48,11 @@ class OfferGetRequestTest extends RequestSpecification {
 			final responseError = fromJson(response.contentAsString, Map)
 
 		then:
-			resultContentIs("$offersUri/$uuid", responseError, BAD_REQUEST, expectedMessage)
+			resultContentIs("$offersUri/$id", responseError, BAD_REQUEST, expectedMessage)
 
 		where:
-			uuid      | expectedMessage
-			'invalid' | "Type mismatch for path variable: Invalid UUID string: $uuid"
+			id        | expectedMessage
+			'invalid' | "Type mismatch for path variable: Invalid UUID string: $id"
 			''        | 'Required path variable Offer id is missing'
 	}
 }

--- a/src/test/groovy/org/sharesquare/hub/endpoints/OfferPostRequestTest.groovy
+++ b/src/test/groovy/org/sharesquare/hub/endpoints/OfferPostRequestTest.groovy
@@ -41,7 +41,7 @@ class OfferPostRequestTest extends RequestSpecification {
 			responseOffer == offer
 
 		when:
-			final getResponse = doGet("$offersUri/${responseOffer.id}")
+			final getResponse = doGet("$offersUri/$responseOffer.id")
 
 		then:
 			fromJson(getResponse.contentAsString) == responseOffer
@@ -145,7 +145,7 @@ class OfferPostRequestTest extends RequestSpecification {
 			responseOffer == offer
 
 		when:
-			final getResponse = doUTF8Get("$offersUri/${responseOffer.id}")
+			final getResponse = doUTF8Get("$offersUri/$responseOffer.id")
 
 		then:
 			fromJson(getResponse.contentAsString) == responseOffer
@@ -176,7 +176,7 @@ class OfferPostRequestTest extends RequestSpecification {
 			}
 
 		when:
-			final getResponse = doGet("$offersUri/${responseOffer.id}")
+			final getResponse = doGet("$offersUri/$responseOffer.id")
 
 		then:
 			fromJson(getResponse.contentAsString) == responseOffer
@@ -200,16 +200,13 @@ class OfferPostRequestTest extends RequestSpecification {
 			responseOffer.startTimezone as String == offer.startTimezone
 
 		when:
-			final getResponse = doGet("$offersUri/${responseOffer.id}")
+			final getResponse = doGet("$offersUri/$responseOffer.id")
 
 		then:
 			fromJson(getResponse.contentAsString) == responseOffer
 	}
 
-	def "A post request with an invalid startTime should respond with status code 400 and a meaningful error message"() {
-		given:
-			final invalidOffer = [startTime: 'x']
-
+	def "A post request with an invalid startTime or startDate or startTimezone should respond with status code 400 and a meaningful error message"() {
 		when:
 			final response = doPost(offersUri, toJson(invalidOffer))
 
@@ -221,42 +218,12 @@ class OfferPostRequestTest extends RequestSpecification {
 
 		then:
 			resultContentIs(offersUri, responseError, BAD_REQUEST)
-			responseError.message.startsWith("JSON parse error for Offer in field 'startTime'")
-	}
+			responseError.message.startsWith("JSON parse error for Offer in field '${(invalidOffer as Map).keySet()[0]}'")
 
-	def "A post request with an invalid startDate should respond with status code 400 and a meaningful error message"() {
-		given:
-			final invalidOffer = [startDate: ',']
-
-		when:
-			final response = doPost(offersUri, toJson(invalidOffer))
-
-		then:
-			resultIs(response, BAD_REQUEST)
-
-		when:
-			final responseError = fromJson(response.contentAsString, Map)
-
-		then:
-			resultContentIs(offersUri, responseError, BAD_REQUEST)
-			responseError.message.startsWith("JSON parse error for Offer in field 'startDate'")
-	}
-
-	def "A post request with an invalid startTimezone should respond with status code 400 and a meaningful error message"() {
-		given:
-			final invalidOffer = [startTimezone: '1 7']
-
-		when:
-			final response = doPost(offersUri, toJson(invalidOffer))
-
-		then:
-			resultIs(response, BAD_REQUEST)
-
-		when:
-			final responseError = fromJson(response.contentAsString, Map)
-
-		then:
-			resultContentIs(offersUri, responseError, BAD_REQUEST)
-			responseError.message.startsWith("JSON parse error for Offer in field 'startTimezone'")
+		where:
+			invalidOffer           | _
+			[startTime: 'x']       | _
+			[startDate: ',']       | _
+			[startTimezone: '1 7'] | _
 	}
 }

--- a/src/test/groovy/org/sharesquare/hub/endpoints/OfferPutRequestTest.groovy
+++ b/src/test/groovy/org/sharesquare/hub/endpoints/OfferPutRequestTest.groovy
@@ -1,0 +1,246 @@
+package org.sharesquare.hub.endpoints
+
+import static org.sharesquare.hub.endpoints.OfferUtil.offersUri
+import static org.sharesquare.hub.endpoints.OfferUtil.userId
+import static org.springframework.http.HttpStatus.BAD_REQUEST
+import static org.springframework.http.HttpStatus.NOT_FOUND
+import static org.springframework.http.HttpStatus.OK
+import static org.springframework.http.HttpStatus.UNSUPPORTED_MEDIA_TYPE
+import static org.springframework.http.MediaType.APPLICATION_JSON_UTF8_VALUE
+import static org.springframework.http.MediaType.TEXT_XML
+
+import org.sharesquare.model.Offer
+
+import spock.lang.Issue
+
+@Issue("#16")
+class OfferPutRequestTest extends RequestSpecification {
+	
+	def existingId
+	
+	def existingId() {
+		existingId != null ? existingId : fromJson(doPost(offersUri, defaultOffer).contentAsString).id
+	}
+
+	def "A valid put request should work and return 200"() {
+		given:
+			def updateOffer = new Offer(id: existingId(),
+				                        userId: '3')
+
+		when:
+			final response = doPut("$offersUri/$updateOffer.id", toJson(updateOffer))
+
+		then:
+			response.status == OK.value
+
+		when:
+			final getResponse = doGet("$offersUri/$updateOffer.id")
+
+		then:
+			fromJson(getResponse.contentAsString) == updateOffer
+	}
+
+	def "A put request with a not existing id should respond with status code 404"() {
+		given:
+			final id = 'f52c1ce2-70d9-4917-a0dc-a0a12a58396e'
+
+		when:
+			final response = doPut("$offersUri/$id", defaultOffer)
+
+		then:
+			response.status == NOT_FOUND.value
+
+
+		when:
+			final getResponse = doGet("$offersUri/$id")
+
+		then:
+			getResponse.status == NOT_FOUND.value
+	}
+
+	def "A put request with an invalid UUID or an empty id should respond with status code 400 and a meaningful error message"() {
+		when:
+			final response = doPut("$offersUri/$id", defaultOffer)
+
+		then:
+			resultIs(response, BAD_REQUEST)
+
+		when:
+			final responseError = fromJson(response.contentAsString, Map)
+
+		then:
+			resultContentIs("$offersUri/$id", responseError, BAD_REQUEST, expectedMessage)
+
+		where:
+			id        | expectedMessage
+			'corrupt' | "Type mismatch for path variable: Invalid UUID string: $id"
+			''        | 'Required path variable Offer id is missing'
+	}
+
+	def "A put request with an empty body should respond with status code 400 and a meaningful error message"() {
+		given:
+			final emptyRequestBody = ''
+
+		when:
+			final id = existingId()
+			final response = doPut("$offersUri/$id", emptyRequestBody)
+
+		then:
+			resultIs(response, BAD_REQUEST)
+
+		when:
+			final responseError = fromJson(response.contentAsString, Map)
+			final expectedMessage = 'Required request body for Offer is missing'
+
+		then:
+			resultContentIs("$offersUri/$id", responseError, BAD_REQUEST, expectedMessage)
+	}
+
+	def "A put request with invalid JSON should respond with status code 400 and a meaningful error message"() {
+		given:
+			final invalidJson = '{]}'
+
+		when:
+			final id = existingId()
+			final response = doPut("$offersUri/$id", invalidJson)
+
+		then:
+			resultIs(response, BAD_REQUEST)
+
+		when:
+			final responseError = fromJson(response.contentAsString, Map)
+			final expectedMessage = "Invalid request body for Offer. JSON parse error: Unexpected close marker ']': expected '}' (for Object starting at [Source: (PushbackInputStream); line: 1, column: 1])"
+
+		then:
+			resultContentIs("$offersUri/$id", responseError, BAD_REQUEST, expectedMessage)
+	}
+
+	def "A put request with a wrong field type in the body should respond with status code 400 and a meaningful error message"() {
+		given:
+			final invalidOffer = [origin: 'string']
+
+		when:
+			final id = existingId()
+			final response = doPut("$offersUri/$id", toJson(invalidOffer))
+
+		then:
+			resultIs(response, BAD_REQUEST)
+
+		when:
+			final responseError = fromJson(response.contentAsString, Map)
+
+		then:
+			resultContentIs("$offersUri/$id", responseError, BAD_REQUEST)
+			responseError.message == "JSON parse error for Offer in field 'origin': Cannot construct instance of `org.sharesquare.model.Location` (although at least one Creator exists): no String-argument constructor/factory method to deserialize from String value ('string')"
+	}
+
+	def "A put request with a not excepted content type should respond with status code 415 and a meaningful error message"() {
+		given:
+			final offerAsXml = "<offer><$userId>4</$userId></offer>"
+
+		when:
+			final id = existingId()
+			final response = doPut("$offersUri/$id", offerAsXml, TEXT_XML)
+
+		then:
+			resultIs(response, UNSUPPORTED_MEDIA_TYPE)
+
+		when:
+			final responseError = fromJson(response.contentAsString, Map)
+			final expectedMessage = "Content type 'text/xml' not supported"
+
+		then:
+			resultContentIs("$offersUri/$id", responseError, UNSUPPORTED_MEDIA_TYPE, expectedMessage)
+	}
+
+	def "A put request with umlaut should work"() {
+		given:
+			def updateOffer = new Offer(id: existingId(),
+				                        userId: '\u00c4') // Ae
+
+		when:
+			final response = doUTF8Put("$offersUri/$updateOffer.id", toJson(updateOffer))
+
+		then:
+			response.status == OK.value
+
+		when:
+			final getResponse = doUTF8Get("$offersUri/$updateOffer.id")
+
+		then:
+			fromJson(getResponse.contentAsString) == updateOffer
+	}
+
+	def "A put request with startTime and startDate should work and have the default startTimezone in the response"() {
+		given:
+			final addOffer = [startTimezone: 'Pacific/Auckland']
+			final updateOffer = [startTime: '10:40',
+				                 startDate: '2016-07-01']
+
+		when:
+			final id = fromJson(doPost(offersUri, toJson(addOffer)).contentAsString).id
+			updateOffer.id = id
+			final response = doPut("$offersUri/$updateOffer.id", toJson(updateOffer))
+
+		then:
+			response.status == OK.value
+
+		when:
+			final getResponse = doGet("$offersUri/$updateOffer.id")
+			final responseOffer = fromJson(getResponse.contentAsString)
+
+		then:
+			with (responseOffer) {
+				id                      != null
+				id                      == updateOffer.id
+				startTime               != null
+				startTime as String     == updateOffer.startTime
+				startDate               != null
+				startDate as String     == updateOffer.startDate
+				startTimezone           != null
+				startTimezone as String == 'Europe/Berlin'
+			}
+	}
+
+	def "A put request with startTimezone should work"() {
+		given:
+			final offer = [startTimezone: 'America/Argentina/Buenos_Aires']
+
+		when:
+			final id = existingId()
+			final response = doPut("$offersUri/$id", toJson(offer))
+
+		then:
+			response.status == OK.value
+			
+		when:
+			final getResponse = doGet("$offersUri/$id")
+			final responseOffer = fromJson(getResponse.contentAsString)
+
+		then:
+			responseOffer.startTimezone != null
+			responseOffer.startTimezone as String == offer.startTimezone
+	}
+
+	def "A put request with an invalid startTime or startDate or startTimezone should respond with status code 400 and a meaningful error message"() {
+		when:
+			final id = existingId()
+			final response = doPut("$offersUri/$id", toJson(invalidOffer))
+
+		then:
+			resultIs(response, BAD_REQUEST)
+
+		when:
+			final responseError = fromJson(response.contentAsString, Map)
+
+		then:
+			resultContentIs("$offersUri/$id", responseError, BAD_REQUEST)
+			responseError.message.startsWith("JSON parse error for Offer in field '${(invalidOffer as Map).keySet()[0]}")
+
+		where:
+			invalidOffer                      | _
+			[startTime: '1:1']                | _
+			[startDate: '2017-5-6']           | _
+			[startTimezone: 'Europe/Rostock'] | _
+	}
+}

--- a/src/test/groovy/org/sharesquare/hub/endpoints/RequestSpecification.groovy
+++ b/src/test/groovy/org/sharesquare/hub/endpoints/RequestSpecification.groovy
@@ -9,6 +9,7 @@ import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print
 
 import org.sharesquare.model.Offer
@@ -140,6 +141,31 @@ class RequestSpecification extends Specification {
 		mvc.perform(
 				get(uri)
 					.header(AUTHORIZATION, "Bearer ${accessToken()}")
+					.accept(APPLICATION_JSON_UTF8)
+			)
+			.andDo(print())
+			.andReturn()
+			.response
+	}
+
+	def doPut(uri, requestBody, mediaType = APPLICATION_JSON) {
+		mvc.perform(
+				put(uri)
+					.header(AUTHORIZATION, "Bearer ${accessToken()}")
+					.contentType(mediaType)
+					.content(requestBody)
+			)
+			.andDo(print())
+			.andReturn()
+			.response
+	}
+
+	def doUTF8Put(uri, requestBody, mediaType = APPLICATION_JSON) {
+		mvc.perform(
+				put(uri)
+					.header(AUTHORIZATION, "Bearer ${accessToken()}")
+					.contentType(mediaType)
+					.content(requestBody)
 					.accept(APPLICATION_JSON_UTF8)
 			)
 			.andDo(print())


### PR DESCRIPTION
Returns

* `200` for an successful Offer update
* `404` if the Offer doesn't exist
* `400` for an invalid/empty Offer id or Offer request body and an error message in the response body
* `415` if the content type is not supported

Test cases are included.