### PR TITLE
Implementation for the GET Offers by userId endpoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,9 @@
 
 FROM openjdk:11.0.3-jdk-slim-stretch AS BUILDER
+ARG SHARE2_OAUTH_CLIENT_ID=123456
+ENV SHARE2_OAUTH_CLIENT_ID=123456
+ARG SHARE2_OAUTH_CLIENT_SECRET=123456
+ENV SHARE2_OAUTH_CLIENT_SECRET=123456
 COPY . .
 RUN ./gradlew clean bootJar
 
@@ -7,8 +11,14 @@ RUN ./gradlew clean bootJar
 FROM openjdk:11.0.3-jdk-slim-stretch
 MAINTAINER zero@dividebyzero.cc
 
+ARG SHARE2_OAUTH_CLIENT_ID=123456
+ENV SHARE2_OAUTH_CLIENT_ID=123456
+
+ARG SHARE2_OAUTH_CLIENT_SECRET=123456
+ENV SHARE2_OAUTH_CLIENT_SECRET=123456
+
 RUN mkdir -p /home/app
 WORKDIR /home/app
 COPY --from=BUILDER /build/libs/share-square-hub.jar ./app.jar
-EXPOSE 8080
+EXPOSE 8081
 ENTRYPOINT java -XX:+PrintFlagsFinal -Djava.security.egd=file:/dev/./urandom $JAVA_OPTIONS -jar app.jar

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,5 @@
 
 FROM openjdk:11.0.3-jdk-slim-stretch AS BUILDER
-ARG SHARE2_OAUTH_CLIENT_ID=123456
-ENV SHARE2_OAUTH_CLIENT_ID=123456
-ARG SHARE2_OAUTH_CLIENT_SECRET=123456
-ENV SHARE2_OAUTH_CLIENT_SECRET=123456
 COPY . .
 RUN ./gradlew clean bootJar
 
@@ -11,14 +7,8 @@ RUN ./gradlew clean bootJar
 FROM openjdk:11.0.3-jdk-slim-stretch
 MAINTAINER zero@dividebyzero.cc
 
-ARG SHARE2_OAUTH_CLIENT_ID=123456
-ENV SHARE2_OAUTH_CLIENT_ID=123456
-
-ARG SHARE2_OAUTH_CLIENT_SECRET=123456
-ENV SHARE2_OAUTH_CLIENT_SECRET=123456
-
 RUN mkdir -p /home/app
 WORKDIR /home/app
 COPY --from=BUILDER /build/libs/share-square-hub.jar ./app.jar
-EXPOSE 8081
+EXPOSE 8080
 ENTRYPOINT java -XX:+PrintFlagsFinal -Djava.security.egd=file:/dev/./urandom $JAVA_OPTIONS -jar app.jar

--- a/README.md
+++ b/README.md
@@ -49,6 +49,6 @@ Use the following settings:
 
 ### Swagger
 
-[http://localhost:8080/swagger-ui.html](http://localhost:8080/swagger-ui.html)
+[http://localhost:8080/api/swagger-ui.html](http://localhost:8080/api/swagger-ui.html)
 
-[http://localhost:8080/v3/api-docs](http://localhost:8080/v3/api-docs)
+[http://localhost:8080/api/v3/api-docs](http://localhost:8080/api/v3/api-docs)

--- a/README.md
+++ b/README.md
@@ -1,16 +1,29 @@
 # share-square-hub
 
-### Short Description
-
 The hub allows different client systems to provide trip offer data to a selection of registered target systems.
 
 ### Deployment
 
+Define your maven repository properties in the **local.properties** file where the library 'share-square-commons' can be found:
+
+* repo.url
+* repo.username
+* repo.password
+
+or use environment variables:
+
+* REPO_URL
+* REPO_USERNAME
+* REPO_PASSWORD
+
+
+Alternatively install the library 'share-square-commons' into your local repository and use `mavenLocal()` in your **build.gradle** instead.
+
 Define authorization properties in the **application.properties** file:
 
-* auth.server.domain
-* auth.server.realm
-* auth.server.scope
+* custom.auth.server.domain
+* custom.auth.server.realm
+* custom.auth.server.scope
 
 or use environment variables:
 
@@ -58,6 +71,6 @@ Use the following settings:
 
 ### Actuator
 
-Endpoints like:
+Endpoints like:  
 [http://localhost:8080/api/actuator/health](http://localhost:8080/api/actuator/health)  
 [http://localhost:8080/api/actuator/beans](http://localhost:8080/api/actuator/beans)

--- a/README.md
+++ b/README.md
@@ -46,3 +46,9 @@ Use the following settings:
 **JDBC URL:** jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1  
 **User Name:** sa  
 **Password:**
+
+### Swagger
+
+[http://localhost:8080/swagger-ui.html](http://localhost:8080/swagger-ui.html)
+
+[http://localhost:8080/v3/api-docs](http://localhost:8080/v3/api-docs)

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Authorize request with header `"Authorization: Bearer {access_token}"`
 
 ### Datasource
 
-The Application runs with a H2 in-memory database. The database web console can be accessed at [http://localhost:8080/h2-console](http://localhost:8080/h2-console).
+The Application runs with a H2 in-memory database. The database web console can be accessed at   [http://localhost:8080/h2-console](http://localhost:8080/h2-console).
 
 Use the following settings:
 
@@ -49,6 +49,11 @@ Use the following settings:
 
 ### Swagger
 
-[http://localhost:8080/api/swagger-ui.html](http://localhost:8080/api/swagger-ui.html)
-
+[http://localhost:8080/api/swagger-ui.html](http://localhost:8080/api/swagger-ui.html)  
 [http://localhost:8080/api/v3/api-docs](http://localhost:8080/api/v3/api-docs)
+
+### Actuator
+
+Endpoints like:
+[http://localhost:8080/api/actuator/health](http://localhost:8080/api/actuator/health)  
+[http://localhost:8080/api/actuator/beans](http://localhost:8080/api/actuator/beans)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # share-square-hub
 
+### Short Description
+
+The hub allows different client systems to provide trip offer data to a selection of registered target systems.
+
 ### Deployment
 
 Define authorization properties in the **application.properties** file:

--- a/README.md
+++ b/README.md
@@ -16,7 +16,6 @@ or use environment variables:
 * REPO_USERNAME
 * REPO_PASSWORD
 
-
 Alternatively install the library 'share-square-commons' into your local repository and use `mavenLocal()` in your **build.gradle** instead.
 
 Define authorization properties in the **application.properties** file:

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ plugins {
 	id 'groovy'
 }
 
-sourceCompatibility = 8
+sourceCompatibility = '1.8'
 
 configurations {
 	compileOnly {

--- a/build.gradle
+++ b/build.gradle
@@ -32,7 +32,7 @@ if (repoPassword == null) repoPassword = properties.getProperty('repo.password')
 
 repositories {
     mavenCentral()
-
+	// mavenLocal()
     maven {
         url = repoUrl
         credentials {

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,4 @@
 plugins {
-    id "io.freefair.lombok" version "4.1.5"
     id 'org.springframework.boot' version '2.3.1.RELEASE'
     id 'io.spring.dependency-management' version '1.0.9.RELEASE'
 	id 'java'

--- a/build.gradle
+++ b/build.gradle
@@ -13,14 +13,22 @@ configurations {
 	}
 }
 
+// read environment variables
+def nexusUrl = System.getenv("NEXUS_URL")
+def nexusUser = System.getenv("NEXUS_USER")
+def nexusPass = System.getenv("NEXUS_PASS")
+
+// read local.properties file
 Properties properties = new Properties()
 def propertiesFile = project.rootProject.file('local.properties')
 if (propertiesFile.exists()) {
     properties.load(propertiesFile.newDataInputStream())
 }
-def nexusUrl = properties.getProperty('nexus.url') != null ? properties.getProperty('nexus.url') : System.getenv("NEXUS_URL")
-def nexusUser = properties.getProperty('nexus.user') != null ? properties.getProperty('nexus.user') : System.getenv("NEXUS_USER")
-def nexusPass = properties.getProperty('nexus.pass') != null ? properties.getProperty('nexus.pass') : System.getenv("NEXUS_PASS")
+
+// environment variables overwrite local properties
+if (nexusUrl == null) nexusUrl = properties.getProperty('nexus.url')
+if (nexusUser == null) nexusUser = properties.getProperty('nexus.user')
+if (nexusPass == null) nexusPass = properties.getProperty('nexus.pass')
 
 repositories {
     mavenCentral()

--- a/build.gradle
+++ b/build.gradle
@@ -62,7 +62,7 @@ dependencies {
     annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
     annotationProcessor 'org.projectlombok:lombok'
     
-    implementation 'org.sharesquare.commons:share-square-commons:0.0.1-SNAPSHOT'
+    implementation 'org.sharesquare.commons:share-square-commons:0.0.2-SNAPSHOT'
 
     testImplementation('org.springframework.boot:spring-boot-starter-test') {
 		exclude group: 'org.junit.vintage', module: 'junit-vintage-engine'

--- a/build.gradle
+++ b/build.gradle
@@ -63,7 +63,6 @@ dependencies {
 
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springdoc:springdoc-openapi-ui:1.4.3'
-    implementation 'org.springframework.data:spring-data-commons:2.3.1.RELEASE'
     implementation 'org.springframework.boot:spring-boot-starter-webflux:2.3.1.RELEASE'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-security'

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,6 @@ plugins {
 }
 
 sourceCompatibility = 8
-targetCompatibility = 8
 
 configurations {
 	compileOnly {

--- a/build.gradle
+++ b/build.gradle
@@ -62,7 +62,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
 
     implementation 'org.springframework.boot:spring-boot-starter-web'
-    implementation 'org.springdoc:springdoc-openapi-ui:1.4.1'
+    implementation 'org.springdoc:springdoc-openapi-ui:1.4.3'
     implementation 'org.springframework.data:spring-data-commons:2.3.1.RELEASE'
     implementation 'org.springframework.boot:spring-boot-starter-webflux:2.3.1.RELEASE'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'

--- a/build.gradle
+++ b/build.gradle
@@ -34,25 +34,6 @@ repositories {
     }
 }
 
-sourceSets {
-    main {
-        java {
-        	srcDirs= ['src/main/java']
-        }
-        resources {
-        	srcDirs= ['src/main/resources']
-        }
-    }
-    test {
-        java {
-        	srcDirs= ['src/test/java','src/test/groovy']
-        }
-        resources {
-        	srcDirs= ['src/test/resources']
-        }
-    }
-}
-
 configurations.all {
     // Check for updates every build
     resolutionStrategy.cacheChangingModulesFor 0, 'seconds'

--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,9 @@ repositories {
             username = nexusUser
             password = nexusPass
         }
+        content {
+            includeGroup 'org.sharesquare.commons'
+        }
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -60,7 +60,6 @@ configurations.all {
 
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
-    implementation group: 'javax.annotation', name: 'javax.annotation-api', version: '1.3.2'
 
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springdoc:springdoc-openapi-ui:1.4.1'

--- a/build.gradle
+++ b/build.gradle
@@ -14,9 +14,9 @@ configurations {
 }
 
 // read environment variables
-def nexusUrl = System.getenv("NEXUS_URL")
-def nexusUser = System.getenv("NEXUS_USER")
-def nexusPass = System.getenv("NEXUS_PASS")
+def repoUrl = System.getenv("REPO_URL")
+def repoUsername = System.getenv("REPO_USERNAME")
+def repoPassword = System.getenv("REPO_PASSWORD")
 
 // read local.properties file
 Properties properties = new Properties()
@@ -26,18 +26,18 @@ if (propertiesFile.exists()) {
 }
 
 // environment variables overwrite local properties
-if (nexusUrl == null) nexusUrl = properties.getProperty('nexus.url')
-if (nexusUser == null) nexusUser = properties.getProperty('nexus.user')
-if (nexusPass == null) nexusPass = properties.getProperty('nexus.pass')
+if (repoUrl == null) repoUrl = properties.getProperty('repo.url')
+if (repoUsername == null) repoUsername = properties.getProperty('repo.username')
+if (repoPassword == null) repoPassword = properties.getProperty('repo.password')
 
 repositories {
     mavenCentral()
 
     maven {
-        url = nexusUrl
+        url = repoUrl
         credentials {
-            username = nexusUser
-            password = nexusPass
+            username = repoUsername
+            password = repoPassword
         }
         content {
             includeGroup 'org.sharesquare.commons'

--- a/build.gradle
+++ b/build.gradle
@@ -34,11 +34,6 @@ repositories {
     }
 }
 
-configurations.all {
-    // Check for updates every build
-    resolutionStrategy.cacheChangingModulesFor 0, 'seconds'
-}
-
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
 
@@ -56,7 +51,7 @@ dependencies {
     annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
     annotationProcessor 'org.projectlombok:lombok'
     
-    implementation group: 'org.sharesquare.commons', name: 'share-square-commons', version: "0.0.1-SNAPSHOT", changing: true
+    implementation 'org.sharesquare.commons:share-square-commons:0.0.1-SNAPSHOT'
 
     testImplementation('org.springframework.boot:spring-boot-starter-test') {
 		exclude group: 'org.junit.vintage', module: 'junit-vintage-engine'

--- a/build.gradle
+++ b/build.gradle
@@ -63,7 +63,6 @@ dependencies {
 
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springdoc:springdoc-openapi-ui:1.4.3'
-    implementation 'org.springframework.boot:spring-boot-starter-webflux:2.3.1.RELEASE'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-oauth2-resource-server'

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,4 @@
+org.gradle.daemon=true
+org.gradle.parallel=true
+org.gradle.configureondemand=true
+org.gradle.jvmargs=-Xmx3g -XX:MaxPermSize=2048m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,0 @@
-org.gradle.daemon=true
-org.gradle.parallel=true
-org.gradle.configureondemand=true
-org.gradle.jvmargs=-Xmx3g -XX:MaxPermSize=2048m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8

--- a/src/main/java/org/sharesquare/hub/configuration/OpenApiConfiguration.java
+++ b/src/main/java/org/sharesquare/hub/configuration/OpenApiConfiguration.java
@@ -35,9 +35,7 @@ public class OpenApiConfiguration {
 				.type(SecurityScheme.Type.HTTP)
 				.scheme("bearer")
 				.bearerFormat("JWT")
-				.name(Constants.AUTHORIZATION_HEADER_NAME)
 				.description(
-						"Authorization header using the Bearer scheme <b>\"Authorization: Bearer &lt;Value&gt;\"</b> where Value is the access token.")
-				.in(SecurityScheme.In.HEADER);
+						"Authorization header using the Bearer scheme <b>\"Authorization: Bearer &lt;Value&gt;\"</b> where Value is the access token.");
 	}
 }

--- a/src/main/java/org/sharesquare/hub/configuration/OpenApiConfiguration.java
+++ b/src/main/java/org/sharesquare/hub/configuration/OpenApiConfiguration.java
@@ -17,7 +17,7 @@ import io.swagger.v3.oas.models.security.SecurityScheme;
 @Configuration
 public class OpenApiConfiguration {
 
-	private static final String AUTH = "OAuth 2.0";
+	private static final String AUTH = "OAuth2.0";
 
     @Bean
     public OpenAPI customOpenAPI() {

--- a/src/main/java/org/sharesquare/hub/configuration/SecurityConfiguration.java
+++ b/src/main/java/org/sharesquare/hub/configuration/SecurityConfiguration.java
@@ -96,6 +96,7 @@ public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
 			.authorizeRequests(authorize -> authorize
 				.mvcMatchers("/v3/api-docs/**", "/swagger-ui.html", "/swagger-ui").permitAll() // Swagger UI
 				.antMatchers("/h2-console/**").permitAll() // H2 Web Console
+				.antMatchers("/actuator/**").permitAll()
 				.mvcMatchers("/offers/**").hasAuthority(SCOPE_PREFIX + scope)
 				.anyRequest().authenticated()
 			)

--- a/src/main/java/org/sharesquare/hub/configuration/SecurityConfiguration.java
+++ b/src/main/java/org/sharesquare/hub/configuration/SecurityConfiguration.java
@@ -10,7 +10,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.http.HttpMethod;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;

--- a/src/main/java/org/sharesquare/hub/configuration/SecurityConfiguration.java
+++ b/src/main/java/org/sharesquare/hub/configuration/SecurityConfiguration.java
@@ -51,7 +51,7 @@ public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
     @Value("${SHARE2_USER_ID_CLAIM:user_id}")
     private String userIdClaim;
 
-	@Value("${auth.server.scope}")
+	@Value("${custom.auth.server.scope}")
 	private String scope;
 
 	@Value("${spring.security.oauth2.resourceserver.jwt.issuer-uri}")

--- a/src/main/java/org/sharesquare/hub/configuration/SecurityConfiguration.java
+++ b/src/main/java/org/sharesquare/hub/configuration/SecurityConfiguration.java
@@ -54,7 +54,7 @@ public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
 	@Value("${auth.server.scope}")
 	private String scope;
 
-	@Value("${auth.server.issuer.uri}")
+	@Value("${spring.security.oauth2.resourceserver.jwt.issuer-uri}")
 	private String issuerUri;
 
 	private static final String SCOPE_PREFIX = "SCOPE_";

--- a/src/main/java/org/sharesquare/hub/configuration/SecurityConfiguration.java
+++ b/src/main/java/org/sharesquare/hub/configuration/SecurityConfiguration.java
@@ -13,7 +13,6 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
-import org.springframework.security.config.annotation.web.builders.WebSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
 import org.springframework.security.config.annotation.web.configurers.oauth2.server.resource.OAuth2ResourceServerConfigurer;
@@ -91,23 +90,12 @@ public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
 	}
 
 	@Override
-	public void configure(WebSecurity web) {
-		web.ignoring().mvcMatchers(
-				// Swagger UI
-				"/v3/api-docs/**", 
-				"/swagger-ui.html", 
-				"/swagger-ui/**",
-				// H2 Web Console
-				"/h2-console/**",
-				"/error/**",
-				"/favicon.ico");
-	}
-
-	@Override
 	protected void configure(HttpSecurity http) throws Exception {
 		http
 			.csrf(csrf -> csrf.disable())
 			.authorizeRequests(authorize -> authorize
+				.mvcMatchers("/v3/api-docs/**", "/swagger-ui.html", "/swagger-ui").permitAll() // Swagger UI
+				.antMatchers("/h2-console/**").permitAll() // H2 Web Console
 				.mvcMatchers("/offers/**").hasAuthority(SCOPE_PREFIX + scope)
 				.anyRequest().authenticated()
 			)
@@ -120,6 +108,8 @@ public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
 		BearerTokenAuthenticationFilter filter = new BearerTokenAuthenticationFilter(authenticationManagerBean());
 		filter.setAuthenticationFailureHandler(authenticationFailureHandler());
 		http.addFilterBefore(filter, BearerTokenAuthenticationFilter.class);
+
+		http.headers().frameOptions().disable(); // for H2 Web Console
     }
         /*
         http

--- a/src/main/java/org/sharesquare/hub/configuration/SystemConfiguration.java
+++ b/src/main/java/org/sharesquare/hub/configuration/SystemConfiguration.java
@@ -22,8 +22,7 @@ public class SystemConfiguration {
 
     private String appName;
 
-
-    @Value("${data.example.usage}")
+    @Value("${custom.data.example.usage}")
 	private boolean useExamples;
 
     @Bean

--- a/src/main/java/org/sharesquare/hub/conversion/OfferConverter.java
+++ b/src/main/java/org/sharesquare/hub/conversion/OfferConverter.java
@@ -28,12 +28,14 @@ import org.sharesquare.model.preferences.PaxSmokerPreference;
 import org.sharesquare.model.preferences.StringPreference;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
 
+@Service
 public class OfferConverter {
 
 	private static final Logger log = LoggerFactory.getLogger(OfferConverter.class);
 
-	public static EntityOffer apiToEntity(Offer offer) {
+	public EntityOffer apiToEntity(Offer offer) {
 		EntityOffer entityOffer = new EntityOffer();
 		entityOffer.setId(offer.getId());
 		entityOffer.setUserId(offer.getUserId());
@@ -106,7 +108,7 @@ public class OfferConverter {
 		return entityOffer;
 	}
 
-	private static EntityLocation apiToEntity(final Location location) {
+	private EntityLocation apiToEntity(final Location location) {
 		if (location != null) {
 			EntityLocation entityLocation = new EntityLocation();
 			entityLocation.setId(location.getId());
@@ -119,7 +121,7 @@ public class OfferConverter {
 		return null;
 	}
 
-	private static EntityContactOption apiToEntity(final ContactOption contactOption) {
+	private EntityContactOption apiToEntity(final ContactOption contactOption) {
 		EntityContactOption entityContactOption = new EntityContactOption();
 		entityContactOption.setId(contactOption.getId());
 		entityContactOption.setContactType(contactOption.getContactType());
@@ -127,7 +129,7 @@ public class OfferConverter {
 		return entityContactOption;
 	}
 
-	public static Offer entityToApi(final EntityOffer entityOffer) {
+	public Offer entityToApi(final EntityOffer entityOffer) {
 		Offer offer = new Offer();
 		offer.setId(entityOffer.getId());
 		offer.setUserId(entityOffer.getUserId());
@@ -200,7 +202,7 @@ public class OfferConverter {
 		return offer;
 	}
 
-	private static Location entityToApi(final EntityLocation entitylocation) {
+	private Location entityToApi(final EntityLocation entitylocation) {
 		if (entitylocation != null) {
 			Location location = new Location();
 			location.setId(entitylocation.getId());
@@ -213,7 +215,7 @@ public class OfferConverter {
 		return null;
 	}
 
-	private static ContactOption entityToApi(final EntityContactOption entityContactOption) {
+	private ContactOption entityToApi(final EntityContactOption entityContactOption) {
 		ContactOption contactOption = new ContactOption();
 		contactOption.setId(entityContactOption.getId());
 		contactOption.setContactType(entityContactOption.getContactType());
@@ -221,7 +223,7 @@ public class OfferConverter {
 		return contactOption;
 	}
 
-	private static <T> Preference<T> entityToApi(Preference<T> preference, final EntityPreference<?> entityPreference) {
+	private <T> Preference<T> entityToApi(Preference<T> preference, final EntityPreference<?> entityPreference) {
 		preference.setId(entityPreference.getId());
 		preference.setKey(entityPreference.getKey());
 		preference.setValue((T) entityPreference.getValue());

--- a/src/main/java/org/sharesquare/hub/conversion/OfferConverter.java
+++ b/src/main/java/org/sharesquare/hub/conversion/OfferConverter.java
@@ -28,12 +28,19 @@ import org.sharesquare.model.preferences.PaxSmokerPreference;
 import org.sharesquare.model.preferences.StringPreference;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 @Service
 public class OfferConverter {
 
 	private static final Logger log = LoggerFactory.getLogger(OfferConverter.class);
+
+	@Autowired
+    private ObjectMapper objectMapper;
 
 	public EntityOffer apiToEntity(Offer offer) {
 		EntityOffer entityOffer = new EntityOffer();
@@ -228,5 +235,14 @@ public class OfferConverter {
 		preference.setKey(entityPreference.getKey());
 		preference.setValue((T) entityPreference.getValue());
 		return preference;
+	}
+
+	public String apiToJSONString(final Offer offer) {
+		try {
+			return objectMapper.writeValueAsString(offer);
+		} catch (JsonProcessingException e) {
+			log.warn("JSON processing problem: " + e.getMessage());
+		}
+		return "";
 	}
 }

--- a/src/main/java/org/sharesquare/hub/conversion/OfferConverter.java
+++ b/src/main/java/org/sharesquare/hub/conversion/OfferConverter.java
@@ -40,7 +40,7 @@ public class OfferConverter {
 	private static final Logger log = LoggerFactory.getLogger(OfferConverter.class);
 
 	@Autowired
-    private ObjectMapper objectMapper;
+	private ObjectMapper objectMapper;
 
 	public EntityOffer apiToEntity(Offer offer) {
 		EntityOffer entityOffer = new EntityOffer();

--- a/src/main/java/org/sharesquare/hub/endpoints/Offers.java
+++ b/src/main/java/org/sharesquare/hub/endpoints/Offers.java
@@ -25,6 +25,8 @@ import org.springframework.data.web.SortDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import com.sun.xml.bind.v2.TODO;
+
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -93,6 +95,7 @@ public class Offers {
 			@PageableDefault(page = 0, size = 10) @SortDefault.SortDefaults({
 					@SortDefault(sort = "startDate", direction = Sort.Direction.ASC),
 					@SortDefault(sort = "startTime", direction = Sort.Direction.ASC)}) final Pageable pageable) {
+    	TODO.checkSpec("https://github.com/fahrgemeinschaft/share-square-hub/issues/24");
     	log.info("Offer GET request for userId value '{}' and Pageable instance: {}", userId, pageable);
     	if (userId.trim().length() > 0) {
     		final Page<Offer> offers = offerService.getOffers(userId, pageable);

--- a/src/main/java/org/sharesquare/hub/endpoints/Offers.java
+++ b/src/main/java/org/sharesquare/hub/endpoints/Offers.java
@@ -77,6 +77,9 @@ public class Offers {
     	return new ResponseEntity<>(NOT_FOUND);
     }
 
+    @Operation(description = "Find all Offers for a given userId")
+    @ApiResponse(responseCode = "200", description = "Success")
+    @ApiResponse(responseCode = "400", description = "Request parameter userId is missing or empty", content = @Content)
     @GetMapping(produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<Page<Offer>> getOffers(
 			@RequestParam final String userId,

--- a/src/main/java/org/sharesquare/hub/endpoints/Offers.java
+++ b/src/main/java/org/sharesquare/hub/endpoints/Offers.java
@@ -1,13 +1,14 @@
 package org.sharesquare.hub.endpoints;
 
-
 import static org.sharesquare.hub.exception.ErrorMessage.USER_ID_IS_EMPTY;
-import static org.springframework.http.HttpStatus.NO_CONTENT;
+import static org.springframework.http.HttpStatus.CREATED;
 import static org.springframework.http.HttpStatus.NOT_FOUND;
+import static org.springframework.http.HttpStatus.NO_CONTENT;
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.media.Content;
-import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import java.util.UUID;
+
+import javax.validation.Valid;
 
 import org.sharesquare.hub.exception.OfferValidationProblem;
 import org.sharesquare.hub.service.OfferService;
@@ -20,14 +21,12 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.data.web.SortDefault;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.UUID;
-
-import javax.validation.Valid;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
 
 @ApiResponse(responseCode = "401", description = "Wrong client authorization", content = @Content)
 @ApiResponse(responseCode = "403", description = "Client not allowed", content = @Content)
@@ -44,7 +43,7 @@ public class Offers {
     @ApiResponse(responseCode = "200", description = "Success")
     @ApiResponse(responseCode = "404", description = "Offer doesn't exist", content = @Content)
     @ApiResponse(responseCode = "400", description = "Path variable Offer id is invalid or missing", content = @Content)
-    @GetMapping(path = "/{id}", produces = MediaType.APPLICATION_JSON_VALUE)
+    @GetMapping(path = "/{id}", produces = APPLICATION_JSON_VALUE)
     public ResponseEntity<Offer> getOffer(@PathVariable final UUID id) {
     	final Offer offer = offerService.getOffer(id);
     	if (offer != null) {
@@ -57,10 +56,10 @@ public class Offers {
     @ApiResponse(responseCode = "201", description = "Success")
     @ApiResponse(responseCode = "400", description = "Wrong data input", content = @Content)
     @ApiResponse(responseCode = "415", description = "Wrong format", content = @Content)
-    @PostMapping(produces = MediaType.APPLICATION_JSON_VALUE, consumes = MediaType.APPLICATION_JSON_VALUE)
+    @PostMapping(produces = APPLICATION_JSON_VALUE, consumes = APPLICATION_JSON_VALUE)
 	public ResponseEntity<Offer> addOffer(@Valid @RequestBody final Offer offer) {
 		final Offer responseOffer = offerService.addOffer(offer);
-		return new ResponseEntity<>(responseOffer, HttpStatus.CREATED);
+		return new ResponseEntity<>(responseOffer, CREATED);
 	}
 
     @Operation(description = "Update an existing Offer")
@@ -68,7 +67,7 @@ public class Offers {
     @ApiResponse(responseCode = "404", description = "Offer doesn't exist")
     @ApiResponse(responseCode = "400", description = "Wrong data input")
     @ApiResponse(responseCode = "415", description = "Wrong format")
-    @PutMapping(path = "/{id}", produces = MediaType.APPLICATION_JSON_VALUE, consumes = MediaType.APPLICATION_JSON_VALUE)
+    @PutMapping(path = "/{id}", produces = APPLICATION_JSON_VALUE, consumes = APPLICATION_JSON_VALUE)
     public ResponseEntity<Void> updateOffer(@PathVariable final UUID id,
     		                                @Valid @RequestBody final Offer offer) {
     	if (offerService.updateOffer(id, offer)) {
@@ -80,7 +79,7 @@ public class Offers {
     @Operation(description = "Find all Offers for a given userId")
     @ApiResponse(responseCode = "200", description = "Success")
     @ApiResponse(responseCode = "400", description = "Request parameter userId is missing or empty", content = @Content)
-    @GetMapping(produces = MediaType.APPLICATION_JSON_VALUE)
+    @GetMapping(produces = APPLICATION_JSON_VALUE)
     public ResponseEntity<Page<Offer>> getOffers(
 			@RequestParam final String userId,
 			@PageableDefault(page = 0, size = 10) @SortDefault.SortDefaults({
@@ -97,7 +96,7 @@ public class Offers {
     @ApiResponse(responseCode = "204", description = "No content success")
     @ApiResponse(responseCode = "404", description = "Offer doesn't exist")
     @ApiResponse(responseCode = "400", description = "Path variable Offer id is invalid or missing")
-    @DeleteMapping(path = "/{id}", produces = MediaType.APPLICATION_JSON_VALUE)
+    @DeleteMapping(path = "/{id}", produces = APPLICATION_JSON_VALUE)
     public ResponseEntity<Void> deleteOffer(@PathVariable final UUID id) {
     	if (offerService.deleteOffer(id)) {
     		return new ResponseEntity<>(NO_CONTENT);

--- a/src/main/java/org/sharesquare/hub/endpoints/Offers.java
+++ b/src/main/java/org/sharesquare/hub/endpoints/Offers.java
@@ -25,8 +25,6 @@ import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-
 import java.util.UUID;
 
 import javax.validation.Valid;

--- a/src/main/java/org/sharesquare/hub/endpoints/Offers.java
+++ b/src/main/java/org/sharesquare/hub/endpoints/Offers.java
@@ -49,7 +49,7 @@ public class Offers {
     @ApiResponse(responseCode = "400", description = "Path variable Offer id is invalid or missing", content = @Content)
     @GetMapping(path = "/{id}", produces = APPLICATION_JSON_VALUE)
     public ResponseEntity<Offer> getOffer(@PathVariable final UUID id) {
-		log.info("Offer GET request for id value '{}'", id);
+    	log.info("Offer GET request for id value '{}'", id);
     	final Offer offer = offerService.getOffer(id);
     	if (offer != null) {
     		return ResponseEntity.ok(offer);
@@ -62,11 +62,11 @@ public class Offers {
     @ApiResponse(responseCode = "400", description = "Wrong data input", content = @Content)
     @ApiResponse(responseCode = "415", description = "Wrong format", content = @Content)
     @PostMapping(produces = APPLICATION_JSON_VALUE, consumes = APPLICATION_JSON_VALUE)
-	public ResponseEntity<Offer> addOffer(@Valid @RequestBody final Offer offer) {
-		log.info("Offer POST request for Offer instance '{}'", offerConverter.apiToJSONString(offer));
-		final Offer responseOffer = offerService.addOffer(offer);
-		return new ResponseEntity<>(responseOffer, CREATED);
-	}
+    public ResponseEntity<Offer> addOffer(@Valid @RequestBody final Offer offer) {
+    	log.info("Offer POST request for Offer instance '{}'", offerConverter.apiToJSONString(offer));
+    	final Offer responseOffer = offerService.addOffer(offer);
+    	return new ResponseEntity<>(responseOffer, CREATED);
+    }
 
     @Operation(description = "Update an existing Offer")
     @ApiResponse(responseCode = "200", description = "Success")
@@ -95,10 +95,10 @@ public class Offers {
 					@SortDefault(sort = "startTime", direction = Sort.Direction.ASC)}) final Pageable pageable) {
     	log.info("Offer GET request for userId value '{}' and Pageable instance: {}", userId, pageable);
     	if (userId.trim().length() > 0) {
-			final Page<Offer> offers = offerService.getOffers(userId, pageable);
-			return ResponseEntity.ok(offers);
-		}
-		throw new OfferValidationProblem(USER_ID_IS_EMPTY);
+    		final Page<Offer> offers = offerService.getOffers(userId, pageable);
+    		return ResponseEntity.ok(offers);
+    	}
+    	throw new OfferValidationProblem(USER_ID_IS_EMPTY);
     }
 
     @Operation(description = "Delete an Offer")

--- a/src/main/java/org/sharesquare/hub/endpoints/Offers.java
+++ b/src/main/java/org/sharesquare/hub/endpoints/Offers.java
@@ -1,5 +1,6 @@
 package org.sharesquare.hub.endpoints;
 
+import static io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY;
 import static org.sharesquare.hub.exception.ErrorMessage.USER_ID_IS_EMPTY;
 import static org.springframework.http.HttpStatus.CREATED;
 import static org.springframework.http.HttpStatus.NOT_FOUND;
@@ -28,7 +29,11 @@ import org.springframework.web.bind.annotation.*;
 import com.sun.xml.bind.v2.TODO;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.Parameters;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 
 @ApiResponse(responseCode = "401", description = "Wrong client authorization", content = @Content)
@@ -89,6 +94,12 @@ public class Offers {
     @Operation(description = "Find all Offers for a given userId")
     @ApiResponse(responseCode = "200", description = "Success")
     @ApiResponse(responseCode = "400", description = "Request parameter userId is missing or empty", content = @Content)
+    @Parameters({
+    	@Parameter(in = QUERY, name = "page", schema = @Schema(type = "string")),
+    	@Parameter(in = QUERY, name = "size", schema = @Schema(type = "string")),
+    	@Parameter(in = QUERY, name = "sort", content = @Content(array = @ArraySchema(schema = @Schema(type = "string")))),
+    	@Parameter(in = QUERY, name = "pageable", hidden = true)
+    })
     @GetMapping(produces = APPLICATION_JSON_VALUE)
     public ResponseEntity<Page<Offer>> getOffers(
 			@RequestParam final String userId,

--- a/src/main/java/org/sharesquare/hub/endpoints/Offers.java
+++ b/src/main/java/org/sharesquare/hub/endpoints/Offers.java
@@ -10,6 +10,7 @@ import java.util.UUID;
 
 import javax.validation.Valid;
 
+import org.sharesquare.hub.conversion.OfferConverter;
 import org.sharesquare.hub.exception.OfferValidationProblem;
 import org.sharesquare.hub.service.OfferService;
 import org.sharesquare.model.Offer;
@@ -39,12 +40,16 @@ public class Offers {
     @Autowired
     OfferService offerService;
 
+    @Autowired
+    private OfferConverter offerConverter;
+
     @Operation(description = "Get Offer by id")
     @ApiResponse(responseCode = "200", description = "Success")
     @ApiResponse(responseCode = "404", description = "Offer doesn't exist", content = @Content)
     @ApiResponse(responseCode = "400", description = "Path variable Offer id is invalid or missing", content = @Content)
     @GetMapping(path = "/{id}", produces = APPLICATION_JSON_VALUE)
     public ResponseEntity<Offer> getOffer(@PathVariable final UUID id) {
+		log.info("Offer GET request for id value '{}'", id);
     	final Offer offer = offerService.getOffer(id);
     	if (offer != null) {
     		return ResponseEntity.ok(offer);
@@ -58,6 +63,7 @@ public class Offers {
     @ApiResponse(responseCode = "415", description = "Wrong format", content = @Content)
     @PostMapping(produces = APPLICATION_JSON_VALUE, consumes = APPLICATION_JSON_VALUE)
 	public ResponseEntity<Offer> addOffer(@Valid @RequestBody final Offer offer) {
+		log.info("Offer POST request for Offer instance '{}'", offerConverter.apiToJSONString(offer));
 		final Offer responseOffer = offerService.addOffer(offer);
 		return new ResponseEntity<>(responseOffer, CREATED);
 	}
@@ -70,6 +76,8 @@ public class Offers {
     @PutMapping(path = "/{id}", produces = APPLICATION_JSON_VALUE, consumes = APPLICATION_JSON_VALUE)
     public ResponseEntity<Void> updateOffer(@PathVariable final UUID id,
     		                                @Valid @RequestBody final Offer offer) {
+    	log.info("Offer PUT request for id value '{}' and Offer instance '{}'",
+    			id, offerConverter.apiToJSONString(offer));
     	if (offerService.updateOffer(id, offer)) {
     		return ResponseEntity.ok(null);
     	}
@@ -85,6 +93,7 @@ public class Offers {
 			@PageableDefault(page = 0, size = 10) @SortDefault.SortDefaults({
 					@SortDefault(sort = "startDate", direction = Sort.Direction.ASC),
 					@SortDefault(sort = "startTime", direction = Sort.Direction.ASC)}) final Pageable pageable) {
+    	log.info("Offer GET request for userId value '{}' and Pageable instance: {}", userId, pageable);
     	if (userId.trim().length() > 0) {
 			final Page<Offer> offers = offerService.getOffers(userId, pageable);
 			return ResponseEntity.ok(offers);
@@ -98,6 +107,7 @@ public class Offers {
     @ApiResponse(responseCode = "400", description = "Path variable Offer id is invalid or missing")
     @DeleteMapping(path = "/{id}", produces = APPLICATION_JSON_VALUE)
     public ResponseEntity<Void> deleteOffer(@PathVariable final UUID id) {
+    	log.info("Offer DELETE request for id value '{}'", id);
     	if (offerService.deleteOffer(id)) {
     		return new ResponseEntity<>(NO_CONTENT);
     	}

--- a/src/main/java/org/sharesquare/hub/exception/ErrorMessage.java
+++ b/src/main/java/org/sharesquare/hub/exception/ErrorMessage.java
@@ -16,4 +16,8 @@ public final class ErrorMessage {
 	public static final String JSON_INVALID_PROBLEM = "Invalid JSON input";
 
 	public static final String OFFER_ID_IS_EMPTY = "Required path variable Offer id is missing";
+
+	public static final String USER_ID_IS_EMPTY = "Request parameter userId must not be empty";
+
+	public static final String ID_OR_USER_ID_IS_EMPTY = "Required path variable id or parameter userId is missing";
 }

--- a/src/main/java/org/sharesquare/hub/exception/OfferValidationProblem.java
+++ b/src/main/java/org/sharesquare/hub/exception/OfferValidationProblem.java
@@ -1,0 +1,10 @@
+package org.sharesquare.hub.exception;
+
+public class OfferValidationProblem extends RuntimeException {
+
+	private static final long serialVersionUID = 1L;
+
+	public OfferValidationProblem(String message) {
+		super(message);
+	}
+}

--- a/src/main/java/org/sharesquare/hub/repository/OfferRepository.java
+++ b/src/main/java/org/sharesquare/hub/repository/OfferRepository.java
@@ -3,7 +3,11 @@ package org.sharesquare.hub.repository;
 import java.util.UUID;
 
 import org.sharesquare.hub.model.data.EntityOffer;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.repository.CrudRepository;
 
 public interface OfferRepository extends CrudRepository<EntityOffer, UUID> {
+
+	Page<EntityOffer> findByUserId(String userId, Pageable pageable);
 }

--- a/src/main/java/org/sharesquare/hub/service/OfferService.java
+++ b/src/main/java/org/sharesquare/hub/service/OfferService.java
@@ -1,5 +1,9 @@
 package org.sharesquare.hub.service;
 
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.function.Function;
 
 import org.sharesquare.hub.conversion.OfferConverter;
 import org.sharesquare.hub.model.data.*;
@@ -9,11 +13,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
-
-import java.util.List;
-import java.util.Optional;
-import java.util.UUID;
-import java.util.function.Function;
 
 @Service
 public class OfferService {

--- a/src/main/java/org/sharesquare/hub/service/OfferService.java
+++ b/src/main/java/org/sharesquare/hub/service/OfferService.java
@@ -6,11 +6,14 @@ import org.sharesquare.hub.model.data.*;
 import org.sharesquare.hub.repository.OfferRepository;
 import org.sharesquare.model.Offer;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.function.Function;
 
 @Service
 public class OfferService {
@@ -40,8 +43,6 @@ public class OfferService {
         */
         return null;
     }
-    //TODO: implement CRUD operations
-    //TODO: implement findMany (call through repository)
 
 	public Offer getOffer(final UUID id) {
 		Optional<EntityOffer> entityOffer = offerRepository.findById(id);
@@ -63,6 +64,17 @@ public class OfferService {
 			return true;
 		}
 		return false;
+	}
+
+	public Page<Offer> getOffers(final String userId, final Pageable pageable) {
+		Page<EntityOffer> entityOffers = offerRepository.findByUserId(userId, pageable);
+		Page<Offer> offers = entityOffers.map(new Function<EntityOffer, Offer>() {
+			@Override
+			public Offer apply(EntityOffer entity) {
+				return OfferConverter.entityToApi(entity);
+			}
+		});
+		return offers;
 	}
 
 	public boolean deleteOffer(final UUID id) {

--- a/src/main/java/org/sharesquare/hub/service/OfferService.java
+++ b/src/main/java/org/sharesquare/hub/service/OfferService.java
@@ -20,6 +20,9 @@ public class OfferService {
 
     @Autowired
     private OfferRepository offerRepository;
+    
+    @Autowired
+    private OfferConverter offerConverter;
 
     @Autowired
     private ConnectorService connectorService;
@@ -47,7 +50,7 @@ public class OfferService {
 	public Offer getOffer(final UUID id) {
 		Optional<EntityOffer> entityOffer = offerRepository.findById(id);
 		if (entityOffer.isPresent()) {
-			Offer offer = OfferConverter.entityToApi(entityOffer.get());
+			Offer offer = offerConverter.entityToApi(entityOffer.get());
 			return offer;
 		}
 		return null;
@@ -55,7 +58,7 @@ public class OfferService {
 
 	public Offer addOffer(final Offer offer) {
 		EntityOffer savedOffer = save(null, offer);
-		return OfferConverter.entityToApi(savedOffer);
+		return offerConverter.entityToApi(savedOffer);
 	}
 
 	public boolean updateOffer(final UUID id, final Offer offer) {
@@ -71,7 +74,7 @@ public class OfferService {
 		Page<Offer> offers = entityOffers.map(new Function<EntityOffer, Offer>() {
 			@Override
 			public Offer apply(EntityOffer entity) {
-				return OfferConverter.entityToApi(entity);
+				return offerConverter.entityToApi(entity);
 			}
 		});
 		return offers;
@@ -86,7 +89,7 @@ public class OfferService {
 	}
 
 	private EntityOffer save(final UUID id, final Offer offer) {
-		EntityOffer entityOffer = OfferConverter.apiToEntity(offer);
+		EntityOffer entityOffer = offerConverter.apiToEntity(offer);
 		removeIds(entityOffer);
 		setPreferenceIds(entityOffer);
 		entityOffer.setId(id);

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,6 +1,6 @@
 spring.application.name=Share2Hub
 server.port=${SERVER_PORT:8080}
-server.contextPath=/
+server.servlet.contextPath=/
 
 #keycloak
 auth.server.domain=${SHARE2_AUTH_SERVER_DOMAIN:http://localhost:9080}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -14,6 +14,9 @@ logging.level.org.springframework.security=DEBUG
 
 data.example.usage=true
 
+# DATA WEB
+spring.data.web.pageable.max-page-size=1000
+
 # DATASOURCE
 spring.datasource.url=jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -3,7 +3,7 @@ spring.application.name=Share2Hub
 
 # EMBEDDED SERVER CONFIGURATION
 server.port=${SERVER_PORT:8080}
-# server.servlet.contextPath=/
+# server.servlet.context-path=/
 
 # SPRING MVC
 spring.mvc.servlet.path=/api

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -3,7 +3,7 @@ spring.application.name=Share2Hub
 
 # EMBEDDED SERVER CONFIGURATION
 server.port=${SERVER_PORT:8080}
-server.servlet.contextPath=/
+# server.servlet.contextPath=/
 
 # SPRING MVC
 spring.mvc.servlet.path=/api

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -5,6 +5,9 @@ spring.application.name=Share2Hub
 server.port=${SERVER_PORT:8080}
 server.servlet.contextPath=/
 
+# SPRING MVC
+spring.mvc.servlet.path=/api
+
 # SECURITY AND OAUTH2 RESOURCE SERVER KEYCLOAK
 auth.server.domain=${SHARE2_AUTH_SERVER_DOMAIN:http://localhost:9080}
 auth.server.realm=${SHARE2_AUTH_SERVER_REALM:xxx}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,8 +1,11 @@
+# IDENTITY
 spring.application.name=Share2Hub
+
+# EMBEDDED SERVER CONFIGURATION
 server.port=${SERVER_PORT:8080}
 server.servlet.contextPath=/
 
-#keycloak
+# SECURITY AND OAUTH2 RESOURCE SERVER KEYCLOAK
 auth.server.domain=${SHARE2_AUTH_SERVER_DOMAIN:http://localhost:9080}
 auth.server.realm=${SHARE2_AUTH_SERVER_REALM:xxx}
 auth.server.scope=${SHARE2_AUTH_SERVER_SCOPE:xxx}
@@ -12,13 +15,13 @@ auth.server.issuer.uri=${auth.server.domain}/auth/realms/${auth.server.realm}
 
 logging.level.org.springframework.security=DEBUG
 
-data.example.usage=true
-
 # DATA WEB
 spring.data.web.pageable.max-page-size=1000
 
 # DATASOURCE
 spring.datasource.url=jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1
+
+data.example.usage=true
 
 # JPA
 spring.jpa.open-in-view=false

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -54,3 +54,8 @@ spring.jpa.show-sql=true
 # http://localhost:8081/h2-console
 spring.h2.console.enabled=true
 spring.h2.console.settings.web-allow-others=true
+
+# ACTUATOR
+management.endpoint.health.show-details=always
+management.endpoints.web.exposure.include=*
+management.endpoint.beans.enabled=true

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -17,12 +17,12 @@ server.port=${SERVER_PORT:8080}
 spring.mvc.servlet.path=/api
 
 # SECURITY AND OAUTH2 RESOURCE SERVER KEYCLOAK
-auth.server.domain=${SHARE2_AUTH_SERVER_DOMAIN:http://localhost:9080}
-auth.server.realm=${SHARE2_AUTH_SERVER_REALM:xxx}
-auth.server.scope=${SHARE2_AUTH_SERVER_SCOPE:xxx}
+custom.auth.server.domain=${SHARE2_AUTH_SERVER_DOMAIN:http://localhost:9080}
+custom.auth.server.realm=${SHARE2_AUTH_SERVER_REALM:xxx}
+custom.auth.server.scope=${SHARE2_AUTH_SERVER_SCOPE:xxx}
 
-spring.security.oauth2.resourceserver.jwt.jwk-set-uri=${auth.server.domain}/auth/realms/${auth.server.realm}/protocol/openid-connect/certs
-spring.security.oauth2.resourceserver.jwt.issuer-uri=${auth.server.domain}/auth/realms/${auth.server.realm}
+spring.security.oauth2.resourceserver.jwt.jwk-set-uri=${custom.auth.server.domain}/auth/realms/${custom.auth.server.realm}/protocol/openid-connect/certs
+spring.security.oauth2.resourceserver.jwt.issuer-uri=${custom.auth.server.domain}/auth/realms/${custom.auth.server.realm}
 
 logging.level.org.springframework.security=DEBUG
 
@@ -32,7 +32,7 @@ spring.data.web.pageable.max-page-size=1000
 # DATASOURCE
 spring.datasource.url=jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1
 
-data.example.usage=true
+custom.data.example.usage=true
 
 # JPA
 spring.jpa.open-in-view=false

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -10,20 +10,16 @@
 spring.application.name=Share2Hub
 
 # EMBEDDED SERVER CONFIGURATION
-server.port=${SERVER_PORT:8081}
+server.port=${SERVER_PORT:8080}
 # server.servlet.context-path=/
 
 # SPRING MVC
 spring.mvc.servlet.path=/api
 
 # SECURITY AND OAUTH2 RESOURCE SERVER KEYCLOAK
-# custom.auth.server.domain=${SHARE2_AUTH_SERVER_DOMAIN:http://localhost:9080}
-# custom.auth.server.realm=${SHARE2_AUTH_SERVER_REALM:firsttest}
-# custom.auth.server.scope=${SHARE2_AUTH_SERVER_SCOPE:offers}
-
-custom.auth.server.domain=${SHARE2_AUTH_SERVER_DOMAIN:https://sso-r2g-api-dev.apps.prod.rd2g.de}
-custom.auth.server.realm=${SHARE2_AUTH_SERVER_REALM:master}
-custom.auth.server.scope=${SHARE2_AUTH_SERVER_SCOPE:offers}
+custom.auth.server.domain=${SHARE2_AUTH_SERVER_DOMAIN:http://localhost:9080}
+custom.auth.server.realm=${SHARE2_AUTH_SERVER_REALM:xxx}
+custom.auth.server.scope=${SHARE2_AUTH_SERVER_SCOPE:xxx}
 
 spring.security.oauth2.resourceserver.jwt.jwk-set-uri=${custom.auth.server.domain}/auth/realms/${custom.auth.server.realm}/protocol/openid-connect/certs
 spring.security.oauth2.resourceserver.jwt.issuer-uri=${custom.auth.server.domain}/auth/realms/${custom.auth.server.realm}
@@ -34,16 +30,11 @@ logging.level.org.springframework.security=DEBUG
 spring.data.web.pageable.max-page-size=1000
 
 # DATASOURCE
-# spring.datasource.driverClassName=org.h2.Driver
 spring.datasource.url=jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1
-# spring.datasource.username=sa
-# spring.datasource.password=
 
 custom.data.example.usage=true
 
 # JPA
-# spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
-# spring.jpa.hibernate.ddl-auto=create-drop
 spring.jpa.open-in-view=false
 spring.jpa.show-sql=true
 
@@ -51,7 +42,7 @@ spring.jpa.show-sql=true
 # logging.level.org.springframework.jdbc=DEBUG
 
 # H2 Web Console
-# http://localhost:8081/h2-console
+# http://localhost:8080/h2-console
 spring.h2.console.enabled=true
 spring.h2.console.settings.web-allow-others=true
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -22,7 +22,7 @@ auth.server.realm=${SHARE2_AUTH_SERVER_REALM:xxx}
 auth.server.scope=${SHARE2_AUTH_SERVER_SCOPE:xxx}
 
 spring.security.oauth2.resourceserver.jwt.jwk-set-uri=${auth.server.domain}/auth/realms/${auth.server.realm}/protocol/openid-connect/certs
-auth.server.issuer.uri=${auth.server.domain}/auth/realms/${auth.server.realm}
+spring.security.oauth2.resourceserver.jwt.issuer-uri=${auth.server.domain}/auth/realms/${auth.server.realm}
 
 logging.level.org.springframework.security=DEBUG
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,3 +1,11 @@
+# CORE PROPERTIES
+# debug=true
+
+# LOGGING
+# logging.level.root=DEBUG
+# logging.level.org.springframework=DEBUG
+# logging.level.org.sharesquare=DEBUG
+
 # IDENTITY
 spring.application.name=Share2Hub
 
@@ -29,6 +37,9 @@ data.example.usage=true
 # JPA
 spring.jpa.open-in-view=false
 spring.jpa.show-sql=true
+
+# logging.level.org.hibernate=DEBUG
+# logging.level.org.springframework.jdbc=DEBUG
 
 # H2 Web Console
 # http://localhost:8080/h2-console

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -10,16 +10,20 @@
 spring.application.name=Share2Hub
 
 # EMBEDDED SERVER CONFIGURATION
-server.port=${SERVER_PORT:8080}
+server.port=${SERVER_PORT:8081}
 # server.servlet.context-path=/
 
 # SPRING MVC
 spring.mvc.servlet.path=/api
 
 # SECURITY AND OAUTH2 RESOURCE SERVER KEYCLOAK
-custom.auth.server.domain=${SHARE2_AUTH_SERVER_DOMAIN:http://localhost:9080}
-custom.auth.server.realm=${SHARE2_AUTH_SERVER_REALM:xxx}
-custom.auth.server.scope=${SHARE2_AUTH_SERVER_SCOPE:xxx}
+# custom.auth.server.domain=${SHARE2_AUTH_SERVER_DOMAIN:http://localhost:9080}
+# custom.auth.server.realm=${SHARE2_AUTH_SERVER_REALM:firsttest}
+# custom.auth.server.scope=${SHARE2_AUTH_SERVER_SCOPE:offers}
+
+custom.auth.server.domain=${SHARE2_AUTH_SERVER_DOMAIN:https://sso-r2g-api-dev.apps.prod.rd2g.de}
+custom.auth.server.realm=${SHARE2_AUTH_SERVER_REALM:master}
+custom.auth.server.scope=${SHARE2_AUTH_SERVER_SCOPE:offers}
 
 spring.security.oauth2.resourceserver.jwt.jwk-set-uri=${custom.auth.server.domain}/auth/realms/${custom.auth.server.realm}/protocol/openid-connect/certs
 spring.security.oauth2.resourceserver.jwt.issuer-uri=${custom.auth.server.domain}/auth/realms/${custom.auth.server.realm}
@@ -30,11 +34,16 @@ logging.level.org.springframework.security=DEBUG
 spring.data.web.pageable.max-page-size=1000
 
 # DATASOURCE
+# spring.datasource.driverClassName=org.h2.Driver
 spring.datasource.url=jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1
+# spring.datasource.username=sa
+# spring.datasource.password=
 
 custom.data.example.usage=true
 
 # JPA
+# spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
+# spring.jpa.hibernate.ddl-auto=create-drop
 spring.jpa.open-in-view=false
 spring.jpa.show-sql=true
 
@@ -42,6 +51,6 @@ spring.jpa.show-sql=true
 # logging.level.org.springframework.jdbc=DEBUG
 
 # H2 Web Console
-# http://localhost:8080/h2-console
+# http://localhost:8081/h2-console
 spring.h2.console.enabled=true
 spring.h2.console.settings.web-allow-others=true

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,4 +1,4 @@
-system.appName=Share2Hub
+spring.application.name=Share2Hub
 server.port=${SERVER_PORT:8080}
 server.contextPath=/
 

--- a/src/test/groovy/org/sharesquare/hub/endpoints/AuthTest.groovy
+++ b/src/test/groovy/org/sharesquare/hub/endpoints/AuthTest.groovy
@@ -20,7 +20,7 @@ class AuthTest extends RequestSpecification {
 
 	@Shared token
 
-	@Value("\${token.expired}")
+	@Value("\${custom.token.expired}")
 	private String tokenExpired;
 
 	static final tokenPattern = /(?i)([a-z0-9]+\.){2}[a-z0-9\_\-]+/

--- a/src/test/groovy/org/sharesquare/hub/endpoints/OfferGetRequestTest.groovy
+++ b/src/test/groovy/org/sharesquare/hub/endpoints/OfferGetRequestTest.groovy
@@ -54,6 +54,6 @@ class OfferGetRequestTest extends RequestSpecification {
 		where:
 			id        | expectedMessage
 			'invalid' | "Type mismatch for path variable: Invalid UUID string: $id"
-			''        | 'Required path variable Offer id is missing'
+			''        | 'Required path variable id or parameter userId is missing'
 	}
 }

--- a/src/test/groovy/org/sharesquare/hub/endpoints/OfferUtil.groovy
+++ b/src/test/groovy/org/sharesquare/hub/endpoints/OfferUtil.groovy
@@ -6,6 +6,10 @@ class OfferUtil {
 
 	protected static final userId = 'userId'
 
+	protected static final size = 'size'
+
+	protected static final page = 'page'
+
 	protected static final defaultOffer = '{}'
 
 	protected static final exampleOffer = '''

--- a/src/test/groovy/org/sharesquare/hub/endpoints/OffersGetRequestTest.groovy
+++ b/src/test/groovy/org/sharesquare/hub/endpoints/OffersGetRequestTest.groovy
@@ -1,0 +1,218 @@
+package org.sharesquare.hub.endpoints
+
+import static org.sharesquare.hub.endpoints.OfferUtil.userId
+import static org.sharesquare.hub.endpoints.OfferUtil.size
+import static org.sharesquare.hub.endpoints.OfferUtil.page
+import static org.sharesquare.hub.endpoints.OfferUtil.offersUri
+import static org.springframework.http.HttpStatus.BAD_REQUEST
+import static org.springframework.http.HttpStatus.OK
+
+import spock.lang.Issue
+
+@Issue("#21")
+class OffersGetRequestTest extends RequestSpecification {
+
+	def "A get request with an userId search parameter should return the matching Offers along with status code 200"() {
+		given:
+			String userA = 'a'
+			String userB = 'b'
+			String userC = 'c'
+
+		when:
+			String id1 = fromJson(doPost(offersUri, toJson([userId: userA])).contentAsString).id
+			String id2 = fromJson(doPost(offersUri, toJson([userId: userA])).contentAsString).id
+			String id3 = fromJson(doPost(offersUri, toJson([userId: userB])).contentAsString).id
+
+		and:
+			final responseA = doGet(offersUri, userId, userA)
+			final responseB = doGet(offersUri, userId, userB)
+			final responseC = doGet(offersUri, userId, userC)
+
+		then:
+			resultIs(responseA, OK)
+			resultIs(responseB, OK)
+			resultIs(responseC, OK)
+
+		when:
+			final responseOffersA = fromJson(responseA.contentAsString, Map)
+			final responseOffersB = fromJson(responseB.contentAsString, Map)
+			final responseOffersC = fromJson(responseC.contentAsString, Map)
+
+		and:
+			Set idsA = []
+			responseOffersA.content.each {
+				idsA.add(it.id)
+			}
+
+		then:
+			contentSizeIs(responseOffersA, 2)
+			responseOffersA.content.each {
+				assert it.userId == userA
+			}
+			idsA == [id1, id2] as Set
+
+		and:
+			contentSizeIs(responseOffersB, 1)
+			with (responseOffersB) {
+				content[0].userId == userB
+				content[0].id == id3
+			}
+
+		and:
+			contentSizeIs(responseOffersC, 0)
+	}
+
+	def "A get request with an empty userId search parameter value should respond with status code 400 and a meaningful error message"() {
+		when:
+			final response = doGet(offersUri, userId, '')
+
+		then:
+			resultIs(response, BAD_REQUEST)
+
+		when:
+			final responseError = fromJson(response.contentAsString, Map)
+			final expectedMessage = "Request parameter $userId must not be empty"
+
+		then:
+			resultContentIs(offersUri, responseError, BAD_REQUEST, expectedMessage)
+	}
+
+	def "A get request with a missing userId search parameter should respond with status code 400 and a meaningful error message"() {
+		when:
+			final response = doGet(offersUri, ' ', '')
+
+		then:
+			resultIs(response, BAD_REQUEST)
+
+		when:
+			final responseError = fromJson(response.contentAsString, Map)
+			final expectedMessage = 'Required path variable id or parameter userId is missing'
+
+		then:
+			resultContentIs(offersUri, responseError, BAD_REQUEST, expectedMessage)
+	}
+
+	def "A get request with a size parameter should return the right amount of Offers along with status code 200"() {
+		when:
+			for (int i = 0; i < 2; i++) {
+				doPost(offersUri, toJson([userId: userD]))
+			}
+
+		and:
+			final response = doGet(offersUri, userId, userD, size, requestSize)
+
+		then:
+			resultIs(response, OK)
+
+		when:
+			final responseOffers = fromJson(response.contentAsString, Map)
+
+		then:
+			contentSizeIs(responseOffers, responseSize)
+
+		where:
+			userD | requestSize | responseSize
+			'd1'  | '1'         | 1
+			'd2'  | '2'         | 2
+			'd3'  | '3'         | 2
+	}
+
+	def "A get request with a page parameter should return the right amount of Offers along with status code 200"() {
+		when:
+			for (int i = 0; i < 3; i++) {
+				doPost(offersUri, toJson([userId: userE]))
+			}
+
+		and:
+			final response = doGet(offersUri, userId, userE, size, '2', page, requestPage)
+
+		then:
+			resultIs(response, OK)
+
+		when:
+			final responseOffers = fromJson(response.contentAsString, Map)
+
+		then:
+			contentSizeIs(responseOffers, responseSize)
+
+		where:
+			userE | requestPage | responseSize
+			'e1'  | '0'         | 2
+			'e2'  | '1'         | 1
+			'e3'  | '2'         | 0
+	}
+
+	def "A get request with an userId search parameter should return the matching Offers in the right default order along with status code 200"() {
+		given:
+			String userF = 'f'
+
+		when:
+			doPost(offersUri, toJson([userId: userF, startTime: '11:10', startDate: '2019-08-15']))
+			doPost(offersUri, toJson([userId: userF, startTime: '11:00', startDate: '2019-08-15']))
+			doPost(offersUri, toJson([userId: userF, startTime: '11:20', startDate: '2019-08-10']))
+
+		and:
+			final response = doGet(offersUri, userId, userF)
+
+		then:
+			resultIs(response, OK)
+
+		when:
+			final responseOffers = fromJson(response.contentAsString, Map)
+
+		then:
+			contentSizeIs(responseOffers, 3)
+			with (responseOffers) {
+				content[0].startTime == '11:20'
+				content[1].startTime == '11:00'
+				content[2].startTime == '11:10'
+			}
+	}
+
+	def "A get request with an invalid or too high size parameter should use the default size 10 or max size 12 and respond with status code 200"() {
+		given:
+			int defaultSize = 10
+
+		when:
+			for (int i = 0; i < defaultSize + 3; i++) {
+				doPost(offersUri, toJson([userId: userG]))
+			}
+
+		and:
+			final response = doGet(offersUri, userId, userG, size, requestSize)
+
+		then:
+			resultIs(response, OK)
+
+		when:
+			final responseOffers = fromJson(response.contentAsString, Map)
+
+		then:
+			contentSizeIs(responseOffers, responseSize)
+
+		where:
+			userG | requestSize | responseSize
+			'g1'  | 'twelve'    | 10
+			'g2'  | '20'        | 12
+	}
+
+	def "A get request with an invalid page parameter should use the default page 0 and respond with status code 200"() {
+		given:
+			String userH = 'h'
+
+		when:
+			doPost(offersUri, toJson([userId: userH]))
+
+		and:
+			final response = doGet(offersUri, userId, userH, page, 'two')
+
+		then:
+			resultIs(response, OK)
+
+		when:
+			final responseOffers = fromJson(response.contentAsString, Map)
+
+		then:
+			contentSizeIs(responseOffers, 1)
+	}
+}

--- a/src/test/groovy/org/sharesquare/hub/endpoints/RequestSpecification.groovy
+++ b/src/test/groovy/org/sharesquare/hub/endpoints/RequestSpecification.groovy
@@ -136,6 +136,19 @@ class RequestSpecification extends Specification {
 			.response
 	}
 
+	def doGet(uri, name1, value1, name2 = ' ', value2 = '', name3 = ' ', value3 = '') {
+		mvc.perform(
+				get(uri)
+					.header(AUTHORIZATION, "Bearer ${accessToken()}")
+					.param(name1, value1)
+					.param(name2, value2)
+					.param(name3, value3)
+			)
+			.andDo(print())
+			.andReturn()
+			.response
+	}
+
 	def doUTF8Get(uri) {
 		mvc.perform(
 				get(uri)
@@ -221,5 +234,11 @@ class RequestSpecification extends Specification {
 			}
 			assert path == uri
 		}
+	}
+
+	void contentSizeIs(response, size) {
+		assert response != null
+		assert response.content != null
+		assert response.content.size() == size
 	}
 }

--- a/src/test/groovy/org/sharesquare/hub/endpoints/RequestSpecification.groovy
+++ b/src/test/groovy/org/sharesquare/hub/endpoints/RequestSpecification.groovy
@@ -35,19 +35,19 @@ class RequestSpecification extends Specification {
 	@Autowired
 	ObjectMapper objectMapper
 
-	@Value("\${auth.server.token.uri}")
+	@Value("\${custom.auth.server.token.uri}")
 	private String tokenUri;
 
-	@Value("\${auth.server.client.id}")
+	@Value("\${custom.auth.server.client.id}")
 	private String clientId;
 
-	@Value("\${auth.server.client.secret}")
+	@Value("\${custom.auth.server.client.secret}")
 	private String clientSecret;
 
-	@Value("\${auth.server.client.not.in.scope.id}")
+	@Value("\${custom.auth.server.client.not.in.scope.id}")
 	private String clientNotInScopeId;
 
-	@Value("\${auth.server.client.not.in.scope.secret}")
+	@Value("\${custom.auth.server.client.not.in.scope.secret}")
 	private String clientNotInScopeSecret;
 
 	def authServerResponse(id = clientId, secret = clientSecret) {

--- a/src/test/groovy/org/sharesquare/hub/endpoints/TargetSystemsGetRequestTest.groovy
+++ b/src/test/groovy/org/sharesquare/hub/endpoints/TargetSystemsGetRequestTest.groovy
@@ -29,13 +29,13 @@ class TargetSystemsGetRequestTest extends RequestSpecification {
 			responseTargetSystems.size() == 3
 			names == ['Fahrgemeinschaft.de', 'ride2Go', 'Mitfahrzentrale MiFaZ'] as Set
 			responseTargetSystems.each {
-				it.id instanceof UUID
-				it.id != null
-				it.description instanceof String
-				it.description != null
-				it.description != ''
-				it.vanityUrl instanceof URL
-				it.vanityUrl != null
+				assert it.id instanceof UUID
+				assert it.id != null
+				assert it.description instanceof String
+				assert it.description != null
+				assert it.description != ''
+				assert it.vanityUrl instanceof URL
+				assert it.vanityUrl != null
 			}
 	}
 }

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -19,6 +19,9 @@ logging.level.org.springframework.security=DEBUG
 
 data.example.usage=true
 
+# DATA WEB
+spring.data.web.pageable.max-page-size=12
+
 # DATASOURCE
 spring.datasource.url=jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1
 

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -1,3 +1,6 @@
+# SPRING MVC
+spring.mvc.servlet.path=/api
+
 # SECURITY AND OAUTH2 RESOURCE SERVER KEYCLOAK
 auth.server.domain=${SHARE2_AUTH_SERVER_DOMAIN:http://localhost:9080}
 auth.server.realm=${SHARE2_AUTH_SERVER_REALM:xxx}

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -15,7 +15,8 @@ auth.server.realm=${SHARE2_AUTH_SERVER_REALM:xxx}
 auth.server.scope=${SHARE2_AUTH_SERVER_SCOPE:xxx}
 
 spring.security.oauth2.resourceserver.jwt.jwk-set-uri=${auth.server.domain}/auth/realms/${auth.server.realm}/protocol/openid-connect/certs
-auth.server.issuer.uri=${auth.server.domain}/auth/realms/${auth.server.realm}
+spring.security.oauth2.resourceserver.jwt.issuer-uri=${auth.server.domain}/auth/realms/${auth.server.realm}
+
 auth.server.token.uri=${auth.server.domain}/auth/realms/${auth.server.realm}/protocol/openid-connect/token
 
 auth.server.client.id= ${SHARE2_AUTH_SERVER_CLIENT_ID:xxx}

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -10,26 +10,22 @@ debug=true
 spring.mvc.servlet.path=/api
 
 # SECURITY AND OAUTH2 RESOURCE SERVER KEYCLOAK
-# custom.auth.server.domain=${SHARE2_AUTH_SERVER_DOMAIN:http://localhost:9080}
-# custom.auth.server.realm=${SHARE2_AUTH_SERVER_REALM:firsttest}
-# custom.auth.server.scope=${SHARE2_AUTH_SERVER_SCOPE:offers}
-
-custom.auth.server.domain=${SHARE2_AUTH_SERVER_DOMAIN:https://sso-r2g-api-dev.apps.prod.rd2g.de}
-custom.auth.server.realm=${SHARE2_AUTH_SERVER_REALM:master}
-custom.auth.server.scope=${SHARE2_AUTH_SERVER_SCOPE:offers}
+custom.auth.server.domain=${SHARE2_AUTH_SERVER_DOMAIN:http://localhost:9080}
+custom.auth.server.realm=${SHARE2_AUTH_SERVER_REALM:xxx}
+custom.auth.server.scope=${SHARE2_AUTH_SERVER_SCOPE:xxx}
 
 spring.security.oauth2.resourceserver.jwt.jwk-set-uri=${custom.auth.server.domain}/auth/realms/${custom.auth.server.realm}/protocol/openid-connect/certs
 spring.security.oauth2.resourceserver.jwt.issuer-uri=${custom.auth.server.domain}/auth/realms/${custom.auth.server.realm}
 
 custom.auth.server.token.uri=${custom.auth.server.domain}/auth/realms/${custom.auth.server.realm}/protocol/openid-connect/token
 
-custom.auth.server.client.id= ${SHARE2_AUTH_SERVER_CLIENT_ID:share2-hub-cantamen}
-custom.auth.server.client.secret= ${SHARE2_AUTH_SERVER_CLIENT_SECRET:3b3a0506-d628-4a24-8397-ab0c2b5baebf}
+custom.auth.server.client.id= ${SHARE2_AUTH_SERVER_CLIENT_ID:xxx}
+custom.auth.server.client.secret= ${SHARE2_AUTH_SERVER_CLIENT_SECRET:xxx}
 
-custom.auth.server.client.not.in.scope.id= ${SHARE2_AUTH_SERVER_CLIENT_NOT_IN_SCOPE_ID:share2-hub-test}
-custom.auth.server.client.not.in.scope.secret= ${SHARE2_AUTH_SERVER_CLIENT_NOT_IN_SCOPE_SECRET:cbd1dd2a-5db8-4f05-b46a-7489062c1809}
+custom.auth.server.client.not.in.scope.id= ${SHARE2_AUTH_SERVER_CLIENT_NOT_IN_SCOPE_ID:xxx}
+custom.auth.server.client.not.in.scope.secret= ${SHARE2_AUTH_SERVER_CLIENT_NOT_IN_SCOPE_SECRET:xxx}
 
-custom.token.expired=${SHARE2_AUTH_TOKEN_EXPIRED:eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJ2TXJ4NDhJYlp6a1VhU3Z5ZEhiWlFJcGZ5VzRlOUZlREVyQy04NmNzN3U4In0.eyJqdGkiOiI1YzA3NjE5Zi1iOGU2LTRlNzgtODAxNi1hNGVjYWM0ZDVjZTYiLCJleHAiOjE1ODk4OTk0NDUsIm5iZiI6MCwiaWF0IjoxNTg5ODk1ODQ1LCJpc3MiOiJodHRwczovL3Nzby1yMmctYXBpLWRldi5hcHBzLnByb2QucmQyZy5kZS9hdXRoL3JlYWxtcy9tYXN0ZXIiLCJhdWQiOiJhY2NvdW50Iiwic3ViIjoiNjdkMzE3NTctNTVmMS00NTg4LWFjY2QtZDkwOWVjYWE4Mjc1IiwidHlwIjoiQmVhcmVyIiwiYXpwIjoic2hhcmUyLWh1Yi1jYW50YW1lbiIsImF1dGhfdGltZSI6MCwic2Vzc2lvbl9zdGF0ZSI6IjUxMGU2NjllLWI1YTAtNDFjZC1hOTYyLTczMTI0MDAxMGZhZiIsImFjciI6IjEiLCJyZWFsbV9hY2Nlc3MiOnsicm9sZXMiOlsic2hhcmUyX2h1YiIsInNoYXJlMl9jbGllbnQiLCJvZmZsaW5lX2FjY2VzcyIsInNoYXJlMl9jb25uZWN0b3IiLCJyaWRlMmdvX3VzZXIiLCJ1bWFfYXV0aG9yaXphdGlvbiJdfSwicmVzb3VyY2VfYWNjZXNzIjp7ImFjY291bnQiOnsicm9sZXMiOlsibWFuYWdlLWFjY291bnQiLCJtYW5hZ2UtYWNjb3VudC1saW5rcyIsInZpZXctcHJvZmlsZSJdfX0sInNjb3BlIjoicHJvZmlsZSBlbWFpbCIsImNsaWVudElkIjoic2hhcmUyLWh1Yi1jYW50YW1lbiIsImVtYWlsX3ZlcmlmaWVkIjpmYWxzZSwiY2xpZW50SG9zdCI6IjYyLjE1Ni4xNC4xNjciLCJwcmVmZXJyZWRfdXNlcm5hbWUiOiJzZXJ2aWNlLWFjY291bnQtc2hhcmUyLWh1Yi1jYW50YW1lbiIsImNsaWVudEFkZHJlc3MiOiI2Mi4xNTYuMTQuMTY3In0.Q8PQdef_fvTYlB1i4HHhM-T9i42kFbL6vJJggRQwzRxXtTw8U_pr3n1G7zRx06eTmqv4iq1pvw8WgBKj7CY44S1x5VOncjiIjU_F40Lprr8hhiG3PEnLkRuv_8qKCkb4qzecHTew57B3OVFxRR-6QgZXS_MhBhi3JTc51m7H50Y2kSb8CURcBwwbpwWn9KpEm7m1Fsrqs7cLQ9VUHr4F8k7DtC3tbrcvRL7udXIOjVZ1VMkeoFscFqXY7R87TUc2Y5tKBdL43NfuqPuRzAMtKr_2BdvmYfi71PaoCJcRRZskedghvtQ8WHkEy_CVaPZK71h-rVha8uRojvUvTC1UBA}
+custom.token.expired=${SHARE2_AUTH_TOKEN_EXPIRED:xxx}
 
 # logging.level.org.springframework.security=DEBUG
 
@@ -37,16 +33,11 @@ custom.token.expired=${SHARE2_AUTH_TOKEN_EXPIRED:eyJhbGciOiJSUzI1NiIsInR5cCIgOiA
 spring.data.web.pageable.max-page-size=12
 
 # DATASOURCE
-# spring.datasource.driverClassName=org.h2.Driver
 spring.datasource.url=jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1
-# spring.datasource.username=sa
-# spring.datasource.password=
 
 custom.data.example.usage=true
 
 # JPA
-# spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
-# spring.jpa.hibernate.ddl-auto=create-drop
 spring.jpa.open-in-view=false
 spring.jpa.show-sql=true
 

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -1,3 +1,11 @@
+# CORE PROPERTIES
+debug=true
+
+# LOGGING
+# logging.level.root=DEBUG
+# logging.level.org.springframework=DEBUG
+# logging.level.org.sharesquare=DEBUG
+
 # SPRING MVC
 spring.mvc.servlet.path=/api
 
@@ -18,7 +26,7 @@ auth.server.client.not.in.scope.secret= ${SHARE2_AUTH_SERVER_CLIENT_NOT_IN_SCOPE
 
 token.expired=${SHARE2_AUTH_TOKEN_EXPIRED:xxx}
 
-logging.level.org.springframework.security=DEBUG
+# logging.level.org.springframework.security=DEBUG
 
 # DATA WEB
 spring.data.web.pageable.max-page-size=12
@@ -31,3 +39,6 @@ data.example.usage=true
 # JPA
 spring.jpa.open-in-view=false
 spring.jpa.show-sql=true
+
+# logging.level.org.hibernate=DEBUG
+# logging.level.org.springframework.jdbc=DEBUG

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -10,22 +10,26 @@ debug=true
 spring.mvc.servlet.path=/api
 
 # SECURITY AND OAUTH2 RESOURCE SERVER KEYCLOAK
-custom.auth.server.domain=${SHARE2_AUTH_SERVER_DOMAIN:http://localhost:9080}
-custom.auth.server.realm=${SHARE2_AUTH_SERVER_REALM:xxx}
-custom.auth.server.scope=${SHARE2_AUTH_SERVER_SCOPE:xxx}
+# custom.auth.server.domain=${SHARE2_AUTH_SERVER_DOMAIN:http://localhost:9080}
+# custom.auth.server.realm=${SHARE2_AUTH_SERVER_REALM:firsttest}
+# custom.auth.server.scope=${SHARE2_AUTH_SERVER_SCOPE:offers}
+
+custom.auth.server.domain=${SHARE2_AUTH_SERVER_DOMAIN:https://sso-r2g-api-dev.apps.prod.rd2g.de}
+custom.auth.server.realm=${SHARE2_AUTH_SERVER_REALM:master}
+custom.auth.server.scope=${SHARE2_AUTH_SERVER_SCOPE:offers}
 
 spring.security.oauth2.resourceserver.jwt.jwk-set-uri=${custom.auth.server.domain}/auth/realms/${custom.auth.server.realm}/protocol/openid-connect/certs
 spring.security.oauth2.resourceserver.jwt.issuer-uri=${custom.auth.server.domain}/auth/realms/${custom.auth.server.realm}
 
 custom.auth.server.token.uri=${custom.auth.server.domain}/auth/realms/${custom.auth.server.realm}/protocol/openid-connect/token
 
-custom.auth.server.client.id= ${SHARE2_AUTH_SERVER_CLIENT_ID:xxx}
-custom.auth.server.client.secret= ${SHARE2_AUTH_SERVER_CLIENT_SECRET:xxx}
+custom.auth.server.client.id= ${SHARE2_AUTH_SERVER_CLIENT_ID:share2-hub-cantamen}
+custom.auth.server.client.secret= ${SHARE2_AUTH_SERVER_CLIENT_SECRET:3b3a0506-d628-4a24-8397-ab0c2b5baebf}
 
-custom.auth.server.client.not.in.scope.id= ${SHARE2_AUTH_SERVER_CLIENT_NOT_IN_SCOPE_ID:xxx}
-custom.auth.server.client.not.in.scope.secret= ${SHARE2_AUTH_SERVER_CLIENT_NOT_IN_SCOPE_SECRET:xxx}
+custom.auth.server.client.not.in.scope.id= ${SHARE2_AUTH_SERVER_CLIENT_NOT_IN_SCOPE_ID:share2-hub-test}
+custom.auth.server.client.not.in.scope.secret= ${SHARE2_AUTH_SERVER_CLIENT_NOT_IN_SCOPE_SECRET:cbd1dd2a-5db8-4f05-b46a-7489062c1809}
 
-custom.token.expired=${SHARE2_AUTH_TOKEN_EXPIRED:xxx}
+custom.token.expired=${SHARE2_AUTH_TOKEN_EXPIRED:eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJ2TXJ4NDhJYlp6a1VhU3Z5ZEhiWlFJcGZ5VzRlOUZlREVyQy04NmNzN3U4In0.eyJqdGkiOiI1YzA3NjE5Zi1iOGU2LTRlNzgtODAxNi1hNGVjYWM0ZDVjZTYiLCJleHAiOjE1ODk4OTk0NDUsIm5iZiI6MCwiaWF0IjoxNTg5ODk1ODQ1LCJpc3MiOiJodHRwczovL3Nzby1yMmctYXBpLWRldi5hcHBzLnByb2QucmQyZy5kZS9hdXRoL3JlYWxtcy9tYXN0ZXIiLCJhdWQiOiJhY2NvdW50Iiwic3ViIjoiNjdkMzE3NTctNTVmMS00NTg4LWFjY2QtZDkwOWVjYWE4Mjc1IiwidHlwIjoiQmVhcmVyIiwiYXpwIjoic2hhcmUyLWh1Yi1jYW50YW1lbiIsImF1dGhfdGltZSI6MCwic2Vzc2lvbl9zdGF0ZSI6IjUxMGU2NjllLWI1YTAtNDFjZC1hOTYyLTczMTI0MDAxMGZhZiIsImFjciI6IjEiLCJyZWFsbV9hY2Nlc3MiOnsicm9sZXMiOlsic2hhcmUyX2h1YiIsInNoYXJlMl9jbGllbnQiLCJvZmZsaW5lX2FjY2VzcyIsInNoYXJlMl9jb25uZWN0b3IiLCJyaWRlMmdvX3VzZXIiLCJ1bWFfYXV0aG9yaXphdGlvbiJdfSwicmVzb3VyY2VfYWNjZXNzIjp7ImFjY291bnQiOnsicm9sZXMiOlsibWFuYWdlLWFjY291bnQiLCJtYW5hZ2UtYWNjb3VudC1saW5rcyIsInZpZXctcHJvZmlsZSJdfX0sInNjb3BlIjoicHJvZmlsZSBlbWFpbCIsImNsaWVudElkIjoic2hhcmUyLWh1Yi1jYW50YW1lbiIsImVtYWlsX3ZlcmlmaWVkIjpmYWxzZSwiY2xpZW50SG9zdCI6IjYyLjE1Ni4xNC4xNjciLCJwcmVmZXJyZWRfdXNlcm5hbWUiOiJzZXJ2aWNlLWFjY291bnQtc2hhcmUyLWh1Yi1jYW50YW1lbiIsImNsaWVudEFkZHJlc3MiOiI2Mi4xNTYuMTQuMTY3In0.Q8PQdef_fvTYlB1i4HHhM-T9i42kFbL6vJJggRQwzRxXtTw8U_pr3n1G7zRx06eTmqv4iq1pvw8WgBKj7CY44S1x5VOncjiIjU_F40Lprr8hhiG3PEnLkRuv_8qKCkb4qzecHTew57B3OVFxRR-6QgZXS_MhBhi3JTc51m7H50Y2kSb8CURcBwwbpwWn9KpEm7m1Fsrqs7cLQ9VUHr4F8k7DtC3tbrcvRL7udXIOjVZ1VMkeoFscFqXY7R87TUc2Y5tKBdL43NfuqPuRzAMtKr_2BdvmYfi71PaoCJcRRZskedghvtQ8WHkEy_CVaPZK71h-rVha8uRojvUvTC1UBA}
 
 # logging.level.org.springframework.security=DEBUG
 
@@ -33,11 +37,16 @@ custom.token.expired=${SHARE2_AUTH_TOKEN_EXPIRED:xxx}
 spring.data.web.pageable.max-page-size=12
 
 # DATASOURCE
+# spring.datasource.driverClassName=org.h2.Driver
 spring.datasource.url=jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1
+# spring.datasource.username=sa
+# spring.datasource.password=
 
 custom.data.example.usage=true
 
 # JPA
+# spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
+# spring.jpa.hibernate.ddl-auto=create-drop
 spring.jpa.open-in-view=false
 spring.jpa.show-sql=true
 

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -1,4 +1,4 @@
-#keycloak
+# SECURITY AND OAUTH2 RESOURCE SERVER KEYCLOAK
 auth.server.domain=${SHARE2_AUTH_SERVER_DOMAIN:http://localhost:9080}
 auth.server.realm=${SHARE2_AUTH_SERVER_REALM:xxx}
 auth.server.scope=${SHARE2_AUTH_SERVER_SCOPE:xxx}
@@ -17,13 +17,13 @@ token.expired=${SHARE2_AUTH_TOKEN_EXPIRED:xxx}
 
 logging.level.org.springframework.security=DEBUG
 
-data.example.usage=true
-
 # DATA WEB
 spring.data.web.pageable.max-page-size=12
 
 # DATASOURCE
 spring.datasource.url=jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1
+
+data.example.usage=true
 
 # JPA
 spring.jpa.open-in-view=false

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -10,22 +10,22 @@ debug=true
 spring.mvc.servlet.path=/api
 
 # SECURITY AND OAUTH2 RESOURCE SERVER KEYCLOAK
-auth.server.domain=${SHARE2_AUTH_SERVER_DOMAIN:http://localhost:9080}
-auth.server.realm=${SHARE2_AUTH_SERVER_REALM:xxx}
-auth.server.scope=${SHARE2_AUTH_SERVER_SCOPE:xxx}
+custom.auth.server.domain=${SHARE2_AUTH_SERVER_DOMAIN:http://localhost:9080}
+custom.auth.server.realm=${SHARE2_AUTH_SERVER_REALM:xxx}
+custom.auth.server.scope=${SHARE2_AUTH_SERVER_SCOPE:xxx}
 
-spring.security.oauth2.resourceserver.jwt.jwk-set-uri=${auth.server.domain}/auth/realms/${auth.server.realm}/protocol/openid-connect/certs
-spring.security.oauth2.resourceserver.jwt.issuer-uri=${auth.server.domain}/auth/realms/${auth.server.realm}
+spring.security.oauth2.resourceserver.jwt.jwk-set-uri=${custom.auth.server.domain}/auth/realms/${custom.auth.server.realm}/protocol/openid-connect/certs
+spring.security.oauth2.resourceserver.jwt.issuer-uri=${custom.auth.server.domain}/auth/realms/${custom.auth.server.realm}
 
-auth.server.token.uri=${auth.server.domain}/auth/realms/${auth.server.realm}/protocol/openid-connect/token
+custom.auth.server.token.uri=${custom.auth.server.domain}/auth/realms/${custom.auth.server.realm}/protocol/openid-connect/token
 
-auth.server.client.id= ${SHARE2_AUTH_SERVER_CLIENT_ID:xxx}
-auth.server.client.secret= ${SHARE2_AUTH_SERVER_CLIENT_SECRET:xxx}
+custom.auth.server.client.id= ${SHARE2_AUTH_SERVER_CLIENT_ID:xxx}
+custom.auth.server.client.secret= ${SHARE2_AUTH_SERVER_CLIENT_SECRET:xxx}
 
-auth.server.client.not.in.scope.id= ${SHARE2_AUTH_SERVER_CLIENT_NOT_IN_SCOPE_ID:xxx}
-auth.server.client.not.in.scope.secret= ${SHARE2_AUTH_SERVER_CLIENT_NOT_IN_SCOPE_SECRET:xxx}
+custom.auth.server.client.not.in.scope.id= ${SHARE2_AUTH_SERVER_CLIENT_NOT_IN_SCOPE_ID:xxx}
+custom.auth.server.client.not.in.scope.secret= ${SHARE2_AUTH_SERVER_CLIENT_NOT_IN_SCOPE_SECRET:xxx}
 
-token.expired=${SHARE2_AUTH_TOKEN_EXPIRED:xxx}
+custom.token.expired=${SHARE2_AUTH_TOKEN_EXPIRED:xxx}
 
 # logging.level.org.springframework.security=DEBUG
 
@@ -35,7 +35,7 @@ spring.data.web.pageable.max-page-size=12
 # DATASOURCE
 spring.datasource.url=jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1
 
-data.example.usage=true
+custom.data.example.usage=true
 
 # JPA
 spring.jpa.open-in-view=false


### PR DESCRIPTION
Returns
* `200` with an `Offer` `Page` in the response body when the request parameter value `userId` is not empty
* `400` for missing or empty `userId` and an error message in the response body

Uses `Pageable` for managing the result list by `page`, `size` and `sort`. Default values are
* `0` for `page`
* `10` for `size` with maximum limit `1000`
* sort by `startDate` and `startTime`

Test cases are included.

There are also some Gradle build management updates and some more details in the deployment description file.

Fixes issues found in the Swagger editor online tool concerning api-doc's component security schemes.