### PR TITLE
Client and target request authorization with separate scopes and request management for the belonging offers or target systems by it's client id

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,5 +25,3 @@ local.properties
 .project
 .settings/
 bin/
-
-tmp/

--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,5 @@ local.properties
 .project
 .settings/
 bin/
+
+tmp/

--- a/src/main/java/org/sharesquare/hub/configuration/SecurityConfiguration.java
+++ b/src/main/java/org/sharesquare/hub/configuration/SecurityConfiguration.java
@@ -99,28 +99,28 @@ public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
     @Override
     protected void configure(HttpSecurity http) throws Exception {
     	http
-			.csrf(csrf -> csrf.disable())
-			.authorizeRequests(authorize -> authorize
-				.mvcMatchers("/v3/api-docs/**", "/swagger-ui.html", "/swagger-ui/**").permitAll() // Swagger UI
-				.antMatchers("/h2-console/**").permitAll() // H2 Web Console
-				.antMatchers("/actuator/**").permitAll()
-				.mvcMatchers("/offers/**").hasAuthority(SCOPE_PREFIX + offersScope)
-				.mvcMatchers(GET, "/targetsystems/**").hasAuthority(SCOPE_PREFIX + offersScope)
-				.mvcMatchers(POST, "/targetsystems/**").hasAuthority(SCOPE_PREFIX + targetScope)
-				.mvcMatchers(DELETE, "/targetsystems/**").hasAuthority(SCOPE_PREFIX + targetScope)
-				.anyRequest().authenticated()
-			)
-			.exceptionHandling()
-				.accessDeniedHandler(accessDeniedHandler())
-				.authenticationEntryPoint(authenticationEntryPoint()).and()
-			.sessionManagement(cust -> cust.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
-			.oauth2ResourceServer(OAuth2ResourceServerConfigurer::jwt);
+    		.csrf(csrf -> csrf.disable())
+    		.authorizeRequests(authorize -> authorize
+    			.mvcMatchers("/v3/api-docs/**", "/swagger-ui.html", "/swagger-ui/**").permitAll() // Swagger UI
+    			.antMatchers("/h2-console/**").permitAll() // H2 Web Console
+    			.antMatchers("/actuator/**").permitAll()
+    			.mvcMatchers("/offers/**").hasAuthority(SCOPE_PREFIX + offersScope)
+    			.mvcMatchers(GET, "/targetsystems/**").hasAuthority(SCOPE_PREFIX + offersScope)
+    			.mvcMatchers(POST, "/targetsystems/**").hasAuthority(SCOPE_PREFIX + targetScope)
+    			.mvcMatchers(DELETE, "/targetsystems/**").hasAuthority(SCOPE_PREFIX + targetScope)
+    			.anyRequest().authenticated()
+    		)
+    		.exceptionHandling()
+    			.accessDeniedHandler(accessDeniedHandler())
+    			.authenticationEntryPoint(authenticationEntryPoint()).and()
+    		.sessionManagement(cust -> cust.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+    		.oauth2ResourceServer(OAuth2ResourceServerConfigurer::jwt);
 
-		BearerTokenAuthenticationFilter filter = new BearerTokenAuthenticationFilter(authenticationManagerBean());
-		filter.setAuthenticationFailureHandler(authenticationFailureHandler());
-		http.addFilterBefore(filter, BearerTokenAuthenticationFilter.class);
+    	BearerTokenAuthenticationFilter filter = new BearerTokenAuthenticationFilter(authenticationManagerBean());
+    	filter.setAuthenticationFailureHandler(authenticationFailureHandler());
+    	http.addFilterBefore(filter, BearerTokenAuthenticationFilter.class);
 
-		http.headers().frameOptions().disable(); // for H2 Web Console
+    	http.headers().frameOptions().disable(); // for H2 Web Console
     }
         /*
         http

--- a/src/main/java/org/sharesquare/hub/configuration/SecurityConfiguration.java
+++ b/src/main/java/org/sharesquare/hub/configuration/SecurityConfiguration.java
@@ -1,5 +1,9 @@
 package org.sharesquare.hub.configuration;
 
+import static org.springframework.http.HttpMethod.DELETE;
+import static org.springframework.http.HttpMethod.GET;
+import static org.springframework.http.HttpMethod.POST;
+
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import org.sharesquare.commons.web.security.oauth.resourceserver.KeycloakRealmRoleConverter;
@@ -49,8 +53,11 @@ public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
     @Value("${SHARE2_USER_ID_CLAIM:user_id}")
     private String userIdClaim;
 
-	@Value("${custom.auth.server.scope}")
-	private String scope;
+	@Value("${custom.auth.server.scope.offers}")
+	private String offersScope;
+
+	@Value("${custom.auth.server.scope.target}")
+	private String targetScope;
 
 	@Value("${spring.security.oauth2.resourceserver.jwt.issuer-uri}")
 	private String issuerUri;
@@ -97,7 +104,10 @@ public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
 				.mvcMatchers("/v3/api-docs/**", "/swagger-ui.html", "/swagger-ui/**").permitAll() // Swagger UI
 				.antMatchers("/h2-console/**").permitAll() // H2 Web Console
 				.antMatchers("/actuator/**").permitAll()
-				.mvcMatchers("/offers/**", "/targetSystems/**").hasAuthority(SCOPE_PREFIX + scope)
+				.mvcMatchers("/offers/**").hasAuthority(SCOPE_PREFIX + offersScope)
+				.mvcMatchers(GET, "/targetsystems/**").hasAuthority(SCOPE_PREFIX + offersScope)
+				.mvcMatchers(POST, "/targetsystems/**").hasAuthority(SCOPE_PREFIX + targetScope)
+				.mvcMatchers(DELETE, "/targetsystems/**").hasAuthority(SCOPE_PREFIX + targetScope)
 				.anyRequest().authenticated()
 			)
 			.exceptionHandling()

--- a/src/main/java/org/sharesquare/hub/configuration/SecurityConfiguration.java
+++ b/src/main/java/org/sharesquare/hub/configuration/SecurityConfiguration.java
@@ -53,52 +53,52 @@ public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
     @Value("${SHARE2_USER_ID_CLAIM:user_id}")
     private String userIdClaim;
 
-	@Value("${custom.auth.server.scope.offers}")
-	private String offersScope;
+    @Value("${custom.auth.server.scope.offers}")
+    private String offersScope;
 
-	@Value("${custom.auth.server.scope.target}")
-	private String targetScope;
+    @Value("${custom.auth.server.scope.target}")
+    private String targetScope;
 
-	@Value("${spring.security.oauth2.resourceserver.jwt.issuer-uri}")
-	private String issuerUri;
+    @Value("${spring.security.oauth2.resourceserver.jwt.issuer-uri}")
+    private String issuerUri;
 
-	private static final String SCOPE_PREFIX = "SCOPE_";
+    private static final String SCOPE_PREFIX = "SCOPE_";
 
-	@Bean
-	public JwtDecoder JwtDecoder() {
-		return JwtDecoders.fromIssuerLocation(issuerUri);
-	}
+    @Bean
+    public JwtDecoder JwtDecoder() {
+    	return JwtDecoders.fromIssuerLocation(issuerUri);
+    }
 
-	@Bean
-	RestAccessDeniedHandler accessDeniedHandler() {
-		return new RestAccessDeniedHandler();
-	}
+    @Bean
+    RestAccessDeniedHandler accessDeniedHandler() {
+    	return new RestAccessDeniedHandler();
+    }
 
-	@Bean
-	RestAuthenticationEntryPoint authenticationEntryPoint() {
-		return new RestAuthenticationEntryPoint();
-	}
+    @Bean
+    RestAuthenticationEntryPoint authenticationEntryPoint() {
+    	return new RestAuthenticationEntryPoint();
+    }
 
-	@Bean
-	RestAuthenticationFailureHandler authenticationFailureHandler() {
-		return new RestAuthenticationFailureHandler();
-	}
+    @Bean
+    RestAuthenticationFailureHandler authenticationFailureHandler() {
+    	return new RestAuthenticationFailureHandler();
+    }
 
-	@Bean
-	@Override
-	public AuthenticationManager authenticationManagerBean() throws Exception {
-		return super.authenticationManagerBean();
-	}
+    @Bean
+    @Override
+    public AuthenticationManager authenticationManagerBean() throws Exception {
+    	return super.authenticationManagerBean();
+    }
 
-	@Autowired
-	@Override
-	protected void configure(AuthenticationManagerBuilder auth) throws Exception {
-		// do NOT call super.configure()
-	}
+    @Autowired
+    @Override
+    protected void configure(AuthenticationManagerBuilder auth) throws Exception {
+    	// do NOT call super.configure()
+    }
 
-	@Override
-	protected void configure(HttpSecurity http) throws Exception {
-		http
+    @Override
+    protected void configure(HttpSecurity http) throws Exception {
+    	http
 			.csrf(csrf -> csrf.disable())
 			.authorizeRequests(authorize -> authorize
 				.mvcMatchers("/v3/api-docs/**", "/swagger-ui.html", "/swagger-ui/**").permitAll() // Swagger UI

--- a/src/main/java/org/sharesquare/hub/model/data/EntityTargetSystem.java
+++ b/src/main/java/org/sharesquare/hub/model/data/EntityTargetSystem.java
@@ -39,4 +39,7 @@ public class EntityTargetSystem extends BaseEntity {
 	private EntityConnector connector;
 
 	private boolean active;
+
+	@Column(name = "client_id")
+	private String clientId;
 }

--- a/src/main/java/org/sharesquare/hub/repository/OfferRepository.java
+++ b/src/main/java/org/sharesquare/hub/repository/OfferRepository.java
@@ -1,5 +1,6 @@
 package org.sharesquare.hub.repository;
 
+import java.util.Optional;
 import java.util.UUID;
 
 import org.sharesquare.hub.model.data.EntityOffer;
@@ -9,5 +10,9 @@ import org.springframework.data.repository.CrudRepository;
 
 public interface OfferRepository extends CrudRepository<EntityOffer, UUID> {
 
-	Page<EntityOffer> findByUserId(String userId, Pageable pageable);
+	boolean existsByIdAndClientId(UUID id, String clientId);
+
+	Optional<EntityOffer> findByIdAndClientId(UUID id, String clientId);
+
+	Page<EntityOffer> findByUserIdAndClientId(String userId, String clientId, Pageable pageable);
 }

--- a/src/main/java/org/sharesquare/hub/repository/TargetSystemRepository.java
+++ b/src/main/java/org/sharesquare/hub/repository/TargetSystemRepository.java
@@ -1,9 +1,12 @@
 package org.sharesquare.hub.repository;
 
+import java.util.Optional;
 import java.util.UUID;
 
 import org.sharesquare.hub.model.data.EntityTargetSystem;
 import org.springframework.data.repository.CrudRepository;
 
 public interface TargetSystemRepository extends CrudRepository<EntityTargetSystem, UUID> {
+
+	Optional<EntityTargetSystem> findByIdAndClientId(UUID id, String clientId);
 }

--- a/src/main/java/org/sharesquare/hub/service/AuthorizationService.java
+++ b/src/main/java/org/sharesquare/hub/service/AuthorizationService.java
@@ -1,0 +1,21 @@
+package org.sharesquare.hub.service;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.stereotype.Service;
+
+@Service
+public class AuthorizationService {
+
+	private static final Logger log = LoggerFactory.getLogger(AuthorizationService.class);
+
+	public String getClientId() {
+		Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+		String clientId = ((Jwt) auth.getCredentials()).getClaimAsString("clientId");
+		log.info("for client id " + clientId);
+		return clientId;
+	}
+}

--- a/src/main/java/org/sharesquare/hub/service/ConnectorService.java
+++ b/src/main/java/org/sharesquare/hub/service/ConnectorService.java
@@ -21,8 +21,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.web.reactive.function.client.ClientResponse;
 import org.springframework.web.reactive.function.client.WebClient;
 
-import com.sun.xml.bind.v2.TODO;
-
 import java.net.URI;
 import java.net.URISyntaxException;
 
@@ -66,10 +64,6 @@ public class ConnectorService {
 		List<EntityTargetSystem> targetSystems = targetSystemService.getEntityTargetSystems();
 		EntityConnector connector;
 		ClientResponse response;
-
-		TODO.checkSpec("https://github.com/fahrgemeinschaft/share-square-hub/issues/27");
-		entityOffer.setClientId(exampleTargetConnectorClientName);
-
 		for (EntityTargetSystem targetSystem : targetSystems) {
 			if (targetSystem.isActive()) {
 				connector = targetSystem.getConnector();

--- a/src/main/java/org/sharesquare/hub/service/TargetSystemService.java
+++ b/src/main/java/org/sharesquare/hub/service/TargetSystemService.java
@@ -25,7 +25,7 @@ public class TargetSystemService {
 	private OfferTargetStatusService offerTargetStatusService;
 
 	@Autowired
-    private AuthorizationService authorizationService;
+	private AuthorizationService authorizationService;
 
 	public TargetSystem addTargetSystem(final TargetSystem targetSystem) {
 		String clientId = authorizationService.getClientId();

--- a/src/main/java/org/sharesquare/hub/service/TargetSystemService.java
+++ b/src/main/java/org/sharesquare/hub/service/TargetSystemService.java
@@ -24,9 +24,14 @@ public class TargetSystemService {
 	@Autowired
 	private OfferTargetStatusService offerTargetStatusService;
 
+	@Autowired
+    private AuthorizationService authorizationService;
+
 	public TargetSystem addTargetSystem(final TargetSystem targetSystem) {
+		String clientId = authorizationService.getClientId();
 		EntityTargetSystem entityTargetSystem = targetSystemConverter.apiToEntity(targetSystem);
 		removeIds(entityTargetSystem);
+		entityTargetSystem.setClientId(clientId);
 		EntityTargetSystem savedTargetSystem = targetSystemRepository.save(entityTargetSystem);
 		return targetSystemConverter.entityToApi(savedTargetSystem);
 	}
@@ -39,7 +44,8 @@ public class TargetSystemService {
 	}
 
 	public boolean deleteTargetSystem(final UUID id) {
-		Optional<EntityTargetSystem> entityTargetSystem = targetSystemRepository.findById(id);
+		String clientId = authorizationService.getClientId();
+		Optional<EntityTargetSystem> entityTargetSystem = targetSystemRepository.findByIdAndClientId(id, clientId);
 		if (entityTargetSystem.isPresent()) {
 			offerTargetStatusService.remove(entityTargetSystem.get());
 			targetSystemRepository.deleteById(id);

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -19,7 +19,8 @@ spring.mvc.servlet.path=/api
 # SECURITY AND OAUTH2 RESOURCE SERVER KEYCLOAK
 custom.auth.server.domain=${SHARE2_AUTH_SERVER_DOMAIN:http://localhost:9080}
 custom.auth.server.realm=${SHARE2_AUTH_SERVER_REALM:xxx}
-custom.auth.server.scope=${SHARE2_AUTH_SERVER_SCOPE:xxx}
+custom.auth.server.scope.offers=${SHARE2_AUTH_SERVER_SCOPE_OFFERS:xxx}
+custom.auth.server.scope.target=${SHARE2_AUTH_SERVER_SCOPE_TARGET:xxx}
 
 spring.security.oauth2.resourceserver.jwt.jwk-set-uri=${custom.auth.server.domain}/auth/realms/${custom.auth.server.realm}/protocol/openid-connect/certs
 spring.security.oauth2.resourceserver.jwt.issuer-uri=${custom.auth.server.domain}/auth/realms/${custom.auth.server.realm}

--- a/src/test/groovy/org/sharesquare/hub/endpoints/AuthTest.groovy
+++ b/src/test/groovy/org/sharesquare/hub/endpoints/AuthTest.groovy
@@ -220,10 +220,10 @@ class AuthTest extends RequestSpecification {
 				case 'delete':
 					response = doDelete(path, accessTokenNotInScope())
 					break
-				case 'get1':
+				case 'getById':
 					response = doGet(path, accessTokenNotInScope())
 					break
-				case 'get2':
+				case 'get':
 					response = doGet(path, userId, 'testuser', ' ', '', ' ', '', accessTokenNotInScope())
 					break
 				default:
@@ -244,12 +244,12 @@ class AuthTest extends RequestSpecification {
 			'post'    | offersUri
 			'put'     | "$offersUri/${UUID.randomUUID()}"
 			'delete'  | "$offersUri/${UUID.randomUUID()}"
-			'get1'    | "$offersUri/${UUID.randomUUID()}"
-			'get2'    | offersUri
+			'getById' | "$offersUri/${UUID.randomUUID()}"
+			'get'     | offersUri
 
 			'post'    | targetSystemsUri
 			'delete'  | "$targetSystemsUri/${UUID.randomUUID()}"
-			'get2'    | targetSystemsUri
+			'get'     | targetSystemsUri
 	}
 
 	@Issue("#29")
@@ -274,10 +274,10 @@ class AuthTest extends RequestSpecification {
 						response = doDelete(path, accessToken())
 					}
 					break
-				case 'get1':
+				case 'getById':
 					response = doGet(path, accessTokenInTargetScope())
 					break
-				case 'get2':
+				case 'get':
 					response = doGet(path, userId, 'testuser', ' ', '', ' ', '', accessTokenInTargetScope())
 					break
 				default:
@@ -298,11 +298,11 @@ class AuthTest extends RequestSpecification {
 			'post'    | offersUri
 			'put'     | "$offersUri/${UUID.randomUUID()}"
 			'delete'  | "$offersUri/${UUID.randomUUID()}"
-			'get1'    | "$offersUri/${UUID.randomUUID()}"
-			'get2'    | offersUri
+			'getById' | "$offersUri/${UUID.randomUUID()}"
+			'get'     | offersUri
 
 			'post'    | targetSystemsUri
 			'delete'  | "$targetSystemsUri/${UUID.randomUUID()}"
-			'get2'    | targetSystemsUri
+			'get'     | targetSystemsUri
 	}
 }

--- a/src/test/groovy/org/sharesquare/hub/endpoints/RequestSpecification.groovy
+++ b/src/test/groovy/org/sharesquare/hub/endpoints/RequestSpecification.groovy
@@ -21,7 +21,6 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
-import org.springframework.http.MediaType
 import org.springframework.test.web.servlet.MockMvc
 
 import com.fasterxml.jackson.databind.ObjectMapper
@@ -226,7 +225,7 @@ class RequestSpecification extends Specification {
 		authServerResponse(clientNotInScopeId, clientNotInScopeSecret).data.access_token
 	}
 
-	def doPost(uri, requestBody, MediaType mediaType = APPLICATION_JSON, accessToken = accessToken()) {
+	def doPost(uri, requestBody, mediaType = APPLICATION_JSON, accessToken = accessToken()) {
 		mvc.perform(
 				post(uri)
 					.header(AUTHORIZATION, "Bearer $accessToken")

--- a/src/test/groovy/org/sharesquare/hub/endpoints/RequestSpecification.groovy
+++ b/src/test/groovy/org/sharesquare/hub/endpoints/RequestSpecification.groovy
@@ -21,6 +21,7 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.http.MediaType
 import org.springframework.test.web.servlet.MockMvc
 
 import com.fasterxml.jackson.databind.ObjectMapper
@@ -46,6 +47,18 @@ class RequestSpecification extends Specification {
 
 	@Value("\${custom.auth.server.client.secret}")
 	private clientSecret;
+	
+	@Value("\${custom.auth.server.client.id2}")
+	private clientId2;
+
+	@Value("\${custom.auth.server.client.secret2}")
+	private clientSecret2;
+	
+	@Value("\${custom.auth.server.client.in.target.scope.id}")
+	private clientInTargetScopeId;
+
+	@Value("\${custom.auth.server.client.in.target.scope.secret}")
+	private clientInTargetScopeSecret;
 
 	@Value("\${custom.auth.server.client.not.in.scope.id}")
 	private clientNotInScopeId;
@@ -200,15 +213,23 @@ class RequestSpecification extends Specification {
 	def accessToken() {
 		authServerResponse().data.access_token
 	}
+	
+	def accessToken2() {
+		authServerResponse(clientId2, clientSecret2).data.access_token
+	}
+	
+	def accessTokenInTargetScope() {
+		authServerResponse(clientInTargetScopeId, clientInTargetScopeSecret).data.access_token
+	}
 
 	def accessTokenNotInScope() {
 		authServerResponse(clientNotInScopeId, clientNotInScopeSecret).data.access_token
 	}
 
-	def doPost(uri, requestBody, mediaType = APPLICATION_JSON) {
+	def doPost(uri, requestBody, MediaType mediaType = APPLICATION_JSON, accessToken = accessToken()) {
 		mvc.perform(
 				post(uri)
-					.header(AUTHORIZATION, "Bearer ${accessToken()}")
+					.header(AUTHORIZATION, "Bearer $accessToken")
 					.contentType(mediaType)
 					.content(requestBody)
 			)
@@ -265,20 +286,20 @@ class RequestSpecification extends Specification {
 			.response
 	}
 
-	def doGet(uri) {
+	def doGet(uri, accessToken = accessToken()) {
 		mvc.perform(
 				get(uri)
-					.header(AUTHORIZATION, "Bearer ${accessToken()}")
+					.header(AUTHORIZATION, "Bearer $accessToken")
 			)
 			.andDo(print())
 			.andReturn()
 			.response
 	}
 
-	def doGet(uri, name1, value1, name2 = ' ', value2 = '', name3 = ' ', value3 = '') {
+	def doGet(uri, name1, value1, name2 = ' ', value2 = '', name3 = ' ', value3 = '', accessToken = accessToken()) {
 		mvc.perform(
 				get(uri)
-					.header(AUTHORIZATION, "Bearer ${accessToken()}")
+					.header(AUTHORIZATION, "Bearer $accessToken")
 					.param(name1, value1)
 					.param(name2, value2)
 					.param(name3, value3)
@@ -299,10 +320,10 @@ class RequestSpecification extends Specification {
 			.response
 	}
 
-	def doPut(uri, requestBody, mediaType = APPLICATION_JSON) {
+	def doPut(uri, requestBody, mediaType = APPLICATION_JSON, accessToken = accessToken()) {
 		mvc.perform(
 				put(uri)
-					.header(AUTHORIZATION, "Bearer ${accessToken()}")
+					.header(AUTHORIZATION, "Bearer $accessToken")
 					.contentType(mediaType)
 					.content(requestBody)
 			)
@@ -324,10 +345,10 @@ class RequestSpecification extends Specification {
 			.response
 	}
 
-	def doDelete(uri) {
+	def doDelete(uri, accessToken = accessToken()) {
 		mvc.perform(
 				delete(uri)
-					.header(AUTHORIZATION, "Bearer ${accessToken()}")
+					.header(AUTHORIZATION, "Bearer $accessToken")
 			)
 			.andDo(print())
 			.andReturn()

--- a/src/test/groovy/org/sharesquare/hub/endpoints/RequestSpecification.groovy
+++ b/src/test/groovy/org/sharesquare/hub/endpoints/RequestSpecification.groovy
@@ -59,6 +59,12 @@ class RequestSpecification extends Specification {
 	@Value("\${custom.auth.server.client.in.target.scope.secret}")
 	private clientInTargetScopeSecret;
 
+	@Value("\${custom.auth.server.client.in.target.scope.id2}")
+	private clientInTargetScopeId2;
+
+	@Value("\${custom.auth.server.client.in.target.scope.secret2}")
+	private clientInTargetScopeSecret2;
+
 	@Value("\${custom.auth.server.client.not.in.scope.id}")
 	private clientNotInScopeId;
 
@@ -219,6 +225,10 @@ class RequestSpecification extends Specification {
 	
 	def accessTokenInTargetScope() {
 		authServerResponse(clientInTargetScopeId, clientInTargetScopeSecret).data.access_token
+	}
+
+	def accessTokenInTargetScope2() {
+		authServerResponse(clientInTargetScopeId2, clientInTargetScopeSecret2).data.access_token
 	}
 
 	def accessTokenNotInScope() {

--- a/src/test/groovy/org/sharesquare/hub/endpoints/TargetSystemsGetRequestTest.groovy
+++ b/src/test/groovy/org/sharesquare/hub/endpoints/TargetSystemsGetRequestTest.groovy
@@ -2,10 +2,12 @@ package org.sharesquare.hub.endpoints
 
 import static org.springframework.http.HttpStatus.BAD_REQUEST
 import static org.springframework.http.HttpStatus.CREATED
+import static org.springframework.http.HttpStatus.FORBIDDEN
 import static org.springframework.http.HttpStatus.NOT_FOUND
 import static org.springframework.http.HttpStatus.NO_CONTENT
 import static org.springframework.http.HttpStatus.OK
 import static org.springframework.http.HttpStatus.UNSUPPORTED_MEDIA_TYPE
+import static org.springframework.http.MediaType.APPLICATION_JSON
 import static org.springframework.http.MediaType.TEXT_XML
 
 import org.sharesquare.model.Connector
@@ -15,7 +17,7 @@ import org.springframework.beans.factory.annotation.Value
 import spock.lang.Issue
 import spock.lang.Stepwise
 
-@Issue("#25,#19,#20")
+@Issue("#25,#19,#20,#29")
 @Stepwise
 class TargetSystemsGetRequestTest extends RequestSpecification {
 
@@ -57,9 +59,10 @@ class TargetSystemsGetRequestTest extends RequestSpecification {
 			}
 	}
 
+	@Issue("#11")
 	def "A valid post request should work and return 201"() {
 		when:
-			final response = doPost(targetSystemsUri, targetSystem)
+			final response = doPost(targetSystemsUri, targetSystem, APPLICATION_JSON, accessTokenInTargetScope())
 
 		then:
 			resultIs(response, CREATED)
@@ -101,7 +104,7 @@ class TargetSystemsGetRequestTest extends RequestSpecification {
 			final emptyRequestBody = ''
 
 		when:
-			final response = doPost(targetSystemsUri, emptyRequestBody)
+			final response = doPost(targetSystemsUri, emptyRequestBody, APPLICATION_JSON, accessTokenInTargetScope())
 
 		then:
 			resultIs(response, BAD_REQUEST)
@@ -119,7 +122,7 @@ class TargetSystemsGetRequestTest extends RequestSpecification {
 			final invalidJson = '{{}{!'
 
 		when:
-			final response = doPost(targetSystemsUri, invalidJson)
+			final response = doPost(targetSystemsUri, invalidJson, APPLICATION_JSON, accessTokenInTargetScope())
 
 		then:
 			resultIs(response, BAD_REQUEST)
@@ -137,7 +140,7 @@ class TargetSystemsGetRequestTest extends RequestSpecification {
 			final invalidTargetSystem = [vanityUrl: []]
 
 		when:
-			final response = doPost(targetSystemsUri, toJson(invalidTargetSystem))
+			final response = doPost(targetSystemsUri, toJson(invalidTargetSystem), APPLICATION_JSON, accessTokenInTargetScope())
 
 		then:
 			resultIs(response, BAD_REQUEST)
@@ -155,7 +158,7 @@ class TargetSystemsGetRequestTest extends RequestSpecification {
 			final targetSystemAsXml = "<targetSystem><name>nobody</name></targetSystemr>"
 
 		when:
-			final response = doPost(targetSystemsUri, targetSystemAsXml, TEXT_XML)
+			final response = doPost(targetSystemsUri, targetSystemAsXml, TEXT_XML, accessTokenInTargetScope())
 
 		then:
 			resultIs(response, UNSUPPORTED_MEDIA_TYPE)
@@ -170,8 +173,8 @@ class TargetSystemsGetRequestTest extends RequestSpecification {
 
 	def "A delete request with an existing id should work and respond with status code 204"() {
 		when:
-			final id = fromJson(doPost(targetSystemsUri, targetSystem).contentAsString, TargetSystem).id
-			final response = doDelete("$targetSystemsUri/$id")
+			final id = fromJson(doPost(targetSystemsUri, targetSystem, APPLICATION_JSON, accessTokenInTargetScope()).contentAsString, TargetSystem).id
+			final response = doDelete("$targetSystemsUri/$id", accessTokenInTargetScope())
 
 		then:
 			response.status == NO_CONTENT.value
@@ -196,7 +199,7 @@ class TargetSystemsGetRequestTest extends RequestSpecification {
 			final id = UUID.randomUUID()
 
 		when:
-			final response = doDelete("$targetSystemsUri/$id")
+			final response = doDelete("$targetSystemsUri/$id", accessTokenInTargetScope())
 
 		then:
 			response.status == NOT_FOUND.value
@@ -213,7 +216,7 @@ class TargetSystemsGetRequestTest extends RequestSpecification {
 
 	def "A delete request with an invalid UUID or an empty id should respond with status code 400 and a meaningful error message"() {
 		when:
-			final response = doDelete("$targetSystemsUri/$id")
+			final response = doDelete("$targetSystemsUri/$id", accessTokenInTargetScope())
 
 		then:
 			resultIs(response, BAD_REQUEST)

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -29,6 +29,9 @@ custom.auth.server.client.secret2= ${SHARE2_AUTH_SERVER_CLIENT_SECRET2:xxx}
 custom.auth.server.client.in.target.scope.id= ${SHARE2_AUTH_SERVER_CLIENT_IN_TARGET_SCOPE_ID:xxx}
 custom.auth.server.client.in.target.scope.secret= ${SHARE2_AUTH_SERVER_CLIENT_IN_TARGET_SCOPE_SECRET:xxx}
 
+custom.auth.server.client.in.target.scope.id2= ${SHARE2_AUTH_SERVER_CLIENT_IN_TARGET_SCOPE_ID2:xxx}
+custom.auth.server.client.in.target.scope.secret2= ${SHARE2_AUTH_SERVER_CLIENT_IN_TARGET_SCOPE_SECRET2:xxx}
+
 custom.auth.server.client.not.in.scope.id= ${SHARE2_AUTH_SERVER_CLIENT_NOT_IN_SCOPE_ID:xxx}
 custom.auth.server.client.not.in.scope.secret= ${SHARE2_AUTH_SERVER_CLIENT_NOT_IN_SCOPE_SECRET:xxx}
 

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -12,7 +12,8 @@ spring.mvc.servlet.path=/api
 # SECURITY AND OAUTH2 RESOURCE SERVER KEYCLOAK
 custom.auth.server.domain=${SHARE2_AUTH_SERVER_DOMAIN:http://localhost:9080}
 custom.auth.server.realm=${SHARE2_AUTH_SERVER_REALM:xxx}
-custom.auth.server.scope=${SHARE2_AUTH_SERVER_SCOPE:xxx}
+custom.auth.server.scope.offers=${SHARE2_AUTH_SERVER_SCOPE_OFFERS:xxx}
+custom.auth.server.scope.target=${SHARE2_AUTH_SERVER_SCOPE_TARGET:xxx}
 
 spring.security.oauth2.resourceserver.jwt.jwk-set-uri=${custom.auth.server.domain}/auth/realms/${custom.auth.server.realm}/protocol/openid-connect/certs
 spring.security.oauth2.resourceserver.jwt.issuer-uri=${custom.auth.server.domain}/auth/realms/${custom.auth.server.realm}
@@ -21,6 +22,12 @@ custom.auth.server.token.uri=${custom.auth.server.domain}/auth/realms/${custom.a
 
 custom.auth.server.client.id= ${SHARE2_AUTH_SERVER_CLIENT_ID:xxx}
 custom.auth.server.client.secret= ${SHARE2_AUTH_SERVER_CLIENT_SECRET:xxx}
+
+custom.auth.server.client.id2= ${SHARE2_AUTH_SERVER_CLIENT_ID2:xxx}
+custom.auth.server.client.secret2= ${SHARE2_AUTH_SERVER_CLIENT_SECRET2:xxx}
+
+custom.auth.server.client.in.target.scope.id= ${SHARE2_AUTH_SERVER_CLIENT_IN_TARGET_SCOPE_ID:xxx}
+custom.auth.server.client.in.target.scope.secret= ${SHARE2_AUTH_SERVER_CLIENT_IN_TARGET_SCOPE_SECRET:xxx}
 
 custom.auth.server.client.not.in.scope.id= ${SHARE2_AUTH_SERVER_CLIENT_NOT_IN_SCOPE_ID:xxx}
 custom.auth.server.client.not.in.scope.secret= ${SHARE2_AUTH_SERVER_CLIENT_NOT_IN_SCOPE_SECRET:xxx}


### PR DESCRIPTION
* get client id from request access token
* save it with offers and target systems
* evaluate requests by offers and target systems belonging to this client id
* use different scopes for client and target requests
* test cases are included